### PR TITLE
speedup-available-properties-collection

### DIFF
--- a/src/Famix-Queries/FQBooleanQuery.class.st
+++ b/src/Famix-Queries/FQBooleanQuery.class.st
@@ -51,6 +51,11 @@ FQBooleanQuery class >> property: aSymbol [
 		yourself
 ]
 
+{ #category : #'available parameters' }
+FQBooleanQuery class >> type [
+	^ FM3Boolean
+]
+
 { #category : #testing }
 FQBooleanQuery >> hasComparisonParameters [
 	^ false
@@ -64,11 +69,6 @@ FQBooleanQuery >> runOn: aMooseGroup [
 			([ self property value: entity ]
 				on: MessageNotUnderstood
 				do: [ false ]) ifNil: [ false ] ]
-]
-
-{ #category : #'available parameters' }
-FQBooleanQuery >> type [
-	^ FM3Boolean
 ]
 
 { #category : #printing }

--- a/src/Famix-Queries/FQNumericQuery.class.st
+++ b/src/Famix-Queries/FQNumericQuery.class.st
@@ -69,6 +69,11 @@ FQNumericQuery class >> property: aSymbol comparator: aComparingSymbol valueToCo
 		yourself
 ]
 
+{ #category : #'available parameters' }
+FQNumericQuery class >> type [
+	^ FM3Number
+]
+
 { #category : #comparing }
 FQNumericQuery >> hasSameParametersAs: aQuery [
 	^ (super hasSameParametersAs: aQuery)
@@ -80,11 +85,6 @@ FQNumericQuery >> hasSameParametersAs: aQuery [
 FQNumericQuery >> isValid [
 	^ super isValid
 		and: [ self comparator isSymbol and: [ self valueToCompare isNumber ] ]
-]
-
-{ #category : #'available parameters' }
-FQNumericQuery >> type [
-	^ FM3Number
 ]
 
 { #category : #printing }

--- a/src/Famix-Queries/FQPropertyQuery.class.st
+++ b/src/Famix-Queries/FQPropertyQuery.class.st
@@ -44,6 +44,12 @@ Class {
 	#category : #'Famix-Queries-Queries-Unary'
 }
 
+{ #category : #accessing }
+FQPropertyQuery class >> availablePropertiesFor: aMooseGroup [
+	^ ((aMooseGroup allEntityTypes collect: [ :entity | entity famePropertiesOfType: self type ])
+		fold: [ :availableProperties :entityProperties | availableProperties & entityProperties ]) collect: #implementingSelector
+]
+
 { #category : #'available parameters' }
 FQPropertyQuery class >> comparators [
 	self subclassResponsibility
@@ -60,6 +66,11 @@ FQPropertyQuery class >> label [
 ]
 
 { #category : #'available parameters' }
+FQPropertyQuery class >> type [
+	^ self subclassResponsibility
+]
+
+{ #category : #'available parameters' }
 FQPropertyQuery >> availableProperties [
 	self flag: #FQTest.
 	^ parent
@@ -69,16 +80,7 @@ FQPropertyQuery >> availableProperties [
 
 { #category : #'available parameters' }
 FQPropertyQuery >> availablePropertiesFor: aMooseGroup [
-	| collectedProperties |
-	collectedProperties := aMooseGroup entities
-		collect: [ :entity | 
-			entity mooseDescription allPrimitiveProperties
-				select: [ :prop | prop type class == self type and: prop isMultivalued not ] ].
-	^ collectedProperties
-		ifNotEmpty: [ (collectedProperties
-				fold:
-					[ :availableProperties :entityProperties | availableProperties & entityProperties ])
-				collect: #name ]
+	^ self class availablePropertiesFor: aMooseGroup
 ]
 
 { #category : #default }
@@ -177,9 +179,9 @@ FQPropertyQuery >> storeOn: aStream [
 	self valueToCompare storeOn: aStream
 ]
 
-{ #category : #'available parameters' }
+{ #category : #accessing }
 FQPropertyQuery >> type [
-	^ self subclassResponsibility
+	^ self class type
 ]
 
 { #category : #accessing }

--- a/src/Famix-Queries/FQStringQuery.class.st
+++ b/src/Famix-Queries/FQStringQuery.class.st
@@ -69,6 +69,11 @@ FQStringQuery class >> property: aSymbol comparator: aComparingSymbol valueToCom
 		yourself
 ]
 
+{ #category : #'available parameters' }
+FQStringQuery class >> type [
+	^ FM3String
+]
+
 { #category : #accessing }
 FQStringQuery >> comparator [
 	^ comparator ifNil: [ comparator := #includesSubString: ]
@@ -85,11 +90,6 @@ FQStringQuery >> hasSameParametersAs: aQuery [
 FQStringQuery >> isValid [
 	^ super isValid
 		and: [ self comparator isSymbol and: [ self valueToCompare isString ] ]
-]
-
-{ #category : #'available parameters' }
-FQStringQuery >> type [
-	^ FM3String
 ]
 
 { #category : #printing }

--- a/src/Famix-Queries/Object.extension.st
+++ b/src/Famix-Queries/Object.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #Object }
+
+{ #category : #'*Famix-Queries' }
+Object >> famePropertiesOfType: aFM3Class [
+	"Select the fame properties of a certain type for the entity meta description."
+
+	^ self mooseDescription allPrimitiveProperties select: [ :prop | prop type class = aFM3Class and: [ prop isMultivalued not ] ]
+]


### PR DESCRIPTION
Speed up available properties collection.

- I moved it class side because it's not instance specific
- I did a speed up. On a medium size project this collection of properties was taking 20sec. With this new version it takes 30ms on this model. :)