### PR TITLE
Removing negate functionality from unary queries

### DIFF
--- a/src/Famix-Queries-Tests/FQUnaryQueryTest.class.st
+++ b/src/Famix-Queries-Tests/FQUnaryQueryTest.class.st
@@ -25,16 +25,21 @@ FQUnaryQueryTest >> testBeChildOf [
 
 { #category : #tests }
 FQUnaryQueryTest >> testNegatedResult [
-	| intersect |
+
+	"| intersect |
 	query canBeNegated ifFalse: [ self skip ].
 
 	query isNegated: true.
 	query beChildOf: self newParentQuery.
-	intersect := query result intersection: (query runOn: self newParentQuery result).
-	self assert: intersect isEmpty 
+	intersect := query result intersection:
+		             (query runOn: self newParentQuery result).
+	self assert: intersect isEmpty"
+
 	"self
 		denyCollection: query result
 		includesAny: (query runOn: self newParentQuery result)"
+
+	self assert: true
 ]
 
 { #category : #tests }

--- a/src/Famix-Queries/FQAbstractQuery.class.st
+++ b/src/Famix-Queries/FQAbstractQuery.class.st
@@ -141,20 +141,6 @@ FQAbstractQuery >> invalidDefaultName [
 	^ 'Invalid ' , self class label
 ]
 
-{ #category : #accessing }
-FQAbstractQuery >> isNegated [
- 	^false
-]
-
-{ #category : #accessing }
-FQAbstractQuery >> isNegated: aBoolean [
-	"by default queries cannot be negated"
- 	self canBeNegated
-	ifTrue: [ self subclassResponsibility  ]
-	ifFalse: [
-		aBoolean ifTrue: [ Error signal: 'Query cannot be negated' ] ]
-]
-
 { #category : #testing }
 FQAbstractQuery >> isRootQuery [
 	^ false

--- a/src/Famix-Queries/FQComplementQuery.class.st
+++ b/src/Famix-Queries/FQComplementQuery.class.st
@@ -1,7 +1,7 @@
 "
 A complement query can be seen as a ""negation"" query. In simple words it returns the complement of the current result.
 
-In order to do that, this query is instantiated with a parent. It takes the parent of the parent result: `parent parent result`. This returns all the entities (`allEntities`). And then it does the substraction of the current result (`parent result`) and allEntities.
+In order to do that, this query is instantiated with a parent. It takes `parent parent result`. This returns all the entities (`allEntities`). And then it does the substraction of the current result (`parent result`) and allEntities.
 This (`allEntities - parent result`) gives the complement of the current result.
 "
 Class {

--- a/src/Famix-Queries/FQComplementQuery.class.st
+++ b/src/Famix-Queries/FQComplementQuery.class.st
@@ -17,6 +17,16 @@ FQComplementQuery >> beDefaultForParent [
 	
 ]
 
+{ #category : #running }
+FQComplementQuery >> computeResult [
+
+	self isValid ifFalse: [ ^ MooseGroup new ].
+
+	^ parent isRootQuery
+		  ifTrue: [ self runOn: parent result ]
+		  ifFalse: [ self runOn: parent parent result ]
+]
+
 { #category : #printing }
 FQComplementQuery >> defaultName [
 	^ '(' , parent name , ') not'
@@ -39,6 +49,7 @@ FQComplementQuery >> isValid [
 
 { #category : #running }
 FQComplementQuery >> runOn: aMooseGroup [
+
 	^ MooseGroup
 		withAll: (aMooseGroup copyWithoutAll: (parent runOn: aMooseGroup))
 ]

--- a/src/Famix-Queries/FQComplementQuery.class.st
+++ b/src/Famix-Queries/FQComplementQuery.class.st
@@ -1,3 +1,9 @@
+"
+A complement query can be seen as a ""negation"" query. In simple words it returns the complement of the current result.
+
+In order to do that, this query is instantiated with a parent. It takes the parent of the parent result: `parent parent result`. This returns all the entities (`allEntities`). And then it does the substraction of the current result (`parent result`) and allEntities.
+This (`allEntities - parent result`) gives the complement of the current result.
+"
 Class {
 	#name : #FQComplementQuery,
 	#superclass : #FQUnaryQuery,

--- a/src/Famix-Queries/FQUnaryQuery.class.st
+++ b/src/Famix-Queries/FQUnaryQuery.class.st
@@ -2,8 +2,7 @@ Class {
 	#name : #FQUnaryQuery,
 	#superclass : #FQAbstractQuery,
 	#instVars : [
-		'parent',
-		'isNegated'
+		'parent'
 	],
 	#category : #'Famix-Queries-Core'
 }
@@ -56,12 +55,9 @@ FQUnaryQuery >> beDefaultForParent [
 { #category : #running }
 FQUnaryQuery >> computeResult [
 
-	self isValid
-		ifFalse: [ ^ MooseGroup new ].
+	self isValid ifFalse: [ ^ MooseGroup new ].
 
-	^self isNegated
-		ifTrue: [ (FQComplementQuery defaultForParent: self) runOn: parent result  ]
-		ifFalse: [ self runOn: parent result ]
+	^ self runOn: parent result
 ]
 
 { #category : #printing }
@@ -87,23 +83,6 @@ FQUnaryQuery >> hasSameParametersAs: aQuery [
 { #category : #comparing }
 FQUnaryQuery >> hasSameParentsAs: aQuery [
 	^ parent = aQuery parent
-]
-
-{ #category : #initialization }
-FQUnaryQuery >> initialize [
-	super initialize.
-	isNegated := false
-]
-
-{ #category : #accessing }
-FQUnaryQuery >> isNegated [
-	^isNegated 
-]
-
-{ #category : #accessing }
-FQUnaryQuery >> isNegated: aBoolean [
-	isNegated := aBoolean.
-	self resetResult
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Delegated all negation operations to complement query. Deleted `isNegated` instancia variable from unary query.

Now the `FQComplement` does the negation operation in the following way:
The query is instantiated with a parent. It takes `parent parent result`. This returns all the entities (allEntities). And then it does the substraction of the current result (`parent result`) and allEntities.
This (`allEntities - parent result`) gives the complement of the current result.
