### PR TITLE
Changed the FQResultSizeQuery

### DIFF
--- a/src/Famix-Queries-Tests/FQResultSizeQueryTest.class.st
+++ b/src/Famix-Queries-Tests/FQResultSizeQueryTest.class.st
@@ -17,8 +17,12 @@ FQResultSizeQueryTest >> expectedPrintOnString [
 
 { #category : #running }
 FQResultSizeQueryTest >> expectedResult [
-	^ helper classes
-		select: [ :class | (self innerQuery runOn: class asMooseGroup) size > 20 ]
+
+	| groups |
+	groups := (helper classes allEntityTypes collect: [ :type | 
+		           helper classes allWithType: type ]) asOrderedCollection.
+	^ ((groups select: [ :class | class size > self valueToCompare ]) 
+		   flatCollect: [ :each | each ]) asMooseGroup
 ]
 
 { #category : #running }
@@ -28,10 +32,11 @@ FQResultSizeQueryTest >> innerQuery [
 
 { #category : #running }
 FQResultSizeQueryTest >> newQuery [
+
 	^ FQResultSizeQuery new
-		innerQuery: self innerQuery;
-		comparator: #>;
-		valueToCompare: 20
+		  innerQuery: self innerQuery;
+		  comparator: #>;
+		  valueToCompare: self valueToCompare
 ]
 
 { #category : #'tests - printing' }
@@ -50,10 +55,27 @@ FQResultSizeQueryTest >> testName [
 		equals: 'Invalid Result Size Query'
 ]
 
+{ #category : #tests }
+FQResultSizeQueryTest >> testResult [
+
+	| newRootQuery |
+	newRootQuery := self newParentQuery.
+	query innerQuery: newRootQuery.
+	self
+		assertCollection: query result
+		hasSameElements: (query runOn: newRootQuery result)
+]
+
 { #category : #'tests - running' }
 FQResultSizeQueryTest >> testRunOn [
 	self assert: self expectedResult isNotEmpty.
 	self
 		assertCollection: (query runOn: helper classes)
 		hasSameElements: self expectedResult
+]
+
+{ #category : #running }
+FQResultSizeQueryTest >> valueToCompare [
+
+	^ 20
 ]

--- a/src/Famix-Queries/FQResultSizeQuery.class.st
+++ b/src/Famix-Queries/FQResultSizeQuery.class.st
@@ -1,3 +1,15 @@
+"
+`FQResultSizeQuery` receives a query and compares its entity types with a comparator and a valueToCompare. For example:
+```
+FQResultSizeQuery
+	innerQuery: aBooleanQuery
+	comparator: #>
+	valueToCompare: 100
+```
+This will compare that all the entity types size of `aBooleanQuery` are greater than 100.
+
+_Note: Like in `FQComplementQuery` we have the same problem for the `parent` instance variable. As this query inherits from `FQUnaryQuery` it has the `parent` instance variable. But it makes no sence that this query has a parent. Only a inner query that is used for the computations. This query does not use the parent instance variable for any of the computations. This is a bad design, we know. It will be fixed in the future._
+"
 Class {
 	#name : #FQResultSizeQuery,
 	#superclass : #FQUnaryQuery,
@@ -9,7 +21,7 @@ Class {
 	#category : #'Famix-Queries-Queries-Unary'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 FQResultSizeQuery class >> innerQuery: aQuery comparator: aComparingSymbol valueToCompare: aNumber [
 	^ self new
 		innerQuery: aQuery;
@@ -25,6 +37,7 @@ FQResultSizeQuery class >> label [
 
 { #category : #default }
 FQResultSizeQuery >> beDefaultForParent [
+
 	self innerQuery: (FQRootQuery new result: parent result).
 	self comparator: #>.
 	self valueToCompare: 0
@@ -40,6 +53,14 @@ FQResultSizeQuery >> comparator: anObject [
 	comparator := anObject
 ]
 
+{ #category : #running }
+FQResultSizeQuery >> computeResult [
+
+	self isValid ifFalse: [ ^ MooseGroup new ].
+
+	^ self runOn: innerQuery result
+]
+
 { #category : #printing }
 FQResultSizeQuery >> defaultName [
 	^ '(' , innerQuery name , ') size ' , comparator asString , ' '
@@ -48,13 +69,14 @@ FQResultSizeQuery >> defaultName [
 
 { #category : #printing }
 FQResultSizeQuery >> displayOn: aStream with: aString [
+
 	aStream << aString << ' select: [ :entity | ('.
 	innerQuery displayOn: aStream with: 'entity asMooseGroup'.
 	aStream
 		<< ') size ';
-		<< self comparator asString;
+		<< comparator asString;
 		space;
-		<< self valueToCompare asString;
+		<< valueToCompare asString;
 		<< ' ]'
 ]
 
@@ -77,29 +99,37 @@ FQResultSizeQuery >> innerQuery: anObject [
 
 { #category : #testing }
 FQResultSizeQuery >> isValid [
-	^ (innerQuery isKindOf: FQAbstractQuery)
-		and: [ innerQuery isValid
-				and: [ self comparator isSymbol and: [ self valueToCompare isNumber ] ] ]
+
+	^ (innerQuery class inheritsFrom: FQAbstractQuery) and: [ 
+		  innerQuery isValid and: [ 
+			   comparator isSymbol and: [  valueToCompare isNumber ] ] ]
 ]
 
 { #category : #running }
 FQResultSizeQuery >> runOn: aMooseGroup [
-	^ aMooseGroup
-		select: [ :entity | 
-			(innerQuery runOn: entity asMooseGroup) size
-				perform: self comparator
-				with: self valueToCompare ]
+
+	| groups selectedGroups |
+	"^ aMooseGroup select: [ :entity | 
+		  (innerQuery runOn: entity asMooseGroup) size
+			  perform: self comparator
+			  with: self valueToCompare ]"
+	groups := (aMooseGroup allEntityTypes collect: [ :type | 
+		           aMooseGroup allWithType: type ]) asOrderedCollection.
+	selectedGroups := groups select: [ :each | 
+		                  each size perform: comparator with: valueToCompare ].
+	^ (selectedGroups flatCollect: [ :each | each ]) asMooseGroup
 ]
 
 { #category : #printing }
 FQResultSizeQuery >> storeOn: aStream [
+
 	aStream << self className << ' innerQuery: ('.
 	innerQuery storeOn: aStream.
 	aStream << ') comparator: '.
-	self comparator storeOn: aStream.
+	 comparator storeOn: aStream.
 	aStream
 		<< ' valueToCompare: ';
-		<< self valueToCompare asString
+		<<  valueToCompare asString
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Now `FQResultSizeQuery` computes the comparations in the type entities (Attributes, Classes, GlobalVariables, LocalVariables...) instead of in each entity.