### PR TITLE
Initialize TypeQuery empty

### DIFF
--- a/src/Famix-Queries-Tests/FQAbstractQueryTest.class.st
+++ b/src/Famix-Queries-Tests/FQAbstractQueryTest.class.st
@@ -86,6 +86,7 @@ FQAbstractQueryTest >> testParentSequence [
 
 { #category : #'tests - printing' }
 FQAbstractQueryTest >> testPrintOn [
+
 	self assert: query printString equals: self expectedPrintOnString.
 	self
 		assert: self unConfiguredQuery printString

--- a/src/Famix-Queries-Tests/FQTypeQueryTest.class.st
+++ b/src/Famix-Queries-Tests/FQTypeQueryTest.class.st
@@ -92,7 +92,10 @@ FQTypeQueryTest >> testDisplayOn [
 
 { #category : #tests }
 FQTypeQueryTest >> testIsValid [
-	super testIsValid.
+
+	self assert: query isValid.
+	"Now the Type Query can be empty and can have zero types"
+	self assert: self unConfiguredQuery isValid.
 
 	"Trait"
 	self assert: (self unConfiguredQuery type: FamixTClass) isValid.
@@ -101,8 +104,18 @@ FQTypeQueryTest >> testIsValid [
 
 { #category : #'tests - printing' }
 FQTypeQueryTest >> testName [
+
 	self assert: query name equals: 'Classes, Methods'.
-	self assert: self unConfiguredQuery name equals: 'Invalid Type Query'
+	self assert: self unConfiguredQuery name equals: ''
+]
+
+{ #category : #tests }
+FQTypeQueryTest >> testPrintOn [
+
+	self assert: query printString equals: self expectedPrintOnString.
+	self
+		assert: self unConfiguredQuery printString
+		equals: 'a ' , self actualClass name , ' ()'
 ]
 
 { #category : #'tests - adding - removing' }

--- a/src/Famix-Queries/FQNavigationQuery.class.st
+++ b/src/Famix-Queries/FQNavigationQuery.class.st
@@ -167,10 +167,9 @@ FQNavigationQuery >> availableAssociationsFor: aMooseGroup [
 
 { #category : #default }
 FQNavigationQuery >> beDefaultForParent [
-	self
-		flag:
-			#FQImprove , #FQTest
-				, 'This is a bit of a hack to allow creation of invalid queries'.
+
+	self flag: #FQImprove , #FQTest
+		, 'This is a bit of a hack to allow creation of invalid queries'.
 	directionStrategy := self class directionStrategies first.
 	associationStrategy := FQAllNavigationAssociations new
 ]

--- a/src/Famix-Queries/FQTypeQuery.class.st
+++ b/src/Famix-Queries/FQTypeQuery.class.st
@@ -81,28 +81,33 @@ FQTypeQuery >> availableTypesFor: aMooseGroup [
 
 { #category : #default }
 FQTypeQuery >> beDefaultForParent [
-	self types: self availableTypes
+
+	"Don't do nothing. The previous behavior was to select all the types by default"
+
+	
 ]
 
 { #category : #printing }
 FQTypeQuery >> defaultName [
-	^ String
-		streamContents: [ :s | 
-			self types
-				allButLastDo: [ :type | s << (self class stringForClass: type) << ', ' ].
-			s << (self class stringForClass: self types last) ]
+
+	^ String streamContents: [ :s | 
+		  self types
+			  do: [ :type | s << (self class stringForClass: type) ]
+			  separatedBy: [ s << ', ' ] ]
 ]
 
 { #category : #printing }
 FQTypeQuery >> displayOn: aStream with: aString [
+
 	self types size == 1
-		ifTrue:
-			[ aStream << aString << (self displayStringForType: self types first) ]
-		ifFalse: [ self types
-				allButLastDo:
-					[ :type | aStream << $( << aString << (self displayStringForType: type) << ') | ' ].
-			aStream << $( << aString
-				<< (self displayStringForType: self types last) << $) ]
+		ifTrue: [ 
+		aStream << aString << (self displayStringForType: self types first) ]
+		ifFalse: [ 
+			self types
+				do: [ :type | 
+					aStream << $( << aString << (self displayStringForType: type)
+					<< ')' ]
+				separatedBy: [ aStream << ' | ' ] ]
 ]
 
 { #category : #printing }
@@ -125,8 +130,8 @@ FQTypeQuery >> initialize [
 
 { #category : #testing }
 FQTypeQuery >> isValid [
-	^ self types isNotEmpty
-		and: [ types allSatisfy: [ :type | self typeIsValid: type ] ]
+
+	^ types allSatisfy: [ :type | self typeIsValid: type ]
 ]
 
 { #category : #'adding - removing' }


### PR DESCRIPTION
Now the TypeQuery is initialized empty, that means: with no selected types by default. The user must select the types. We discussed this with Nicolas and Anne.
@NicolasAnquetil could you give a look and see if this PR is ok so I can merge it?