### PR TITLE
Refactoring nary queries

### DIFF
--- a/src/Famix-Queries-Tests/FQAbstractQueryTest.class.st
+++ b/src/Famix-Queries-Tests/FQAbstractQueryTest.class.st
@@ -58,11 +58,6 @@ FQAbstractQueryTest >> testAddChild [
 	self assert: (query children includes: child)
 ]
 
-{ #category : #tests }
-FQAbstractQueryTest >> testBeChildOf [
-	self subclassResponsibility
-]
-
 { #category : #'tests - printing' }
 FQAbstractQueryTest >> testDisplayOn [
 	self subclassResponsibility
@@ -76,11 +71,6 @@ FQAbstractQueryTest >> testIsValid [
 
 { #category : #'tests - printing' }
 FQAbstractQueryTest >> testName [
-	self subclassResponsibility
-]
-
-{ #category : #tests }
-FQAbstractQueryTest >> testParentSequence [
 	self subclassResponsibility
 ]
 

--- a/src/Famix-Queries-Tests/FQComplementQueryTest.class.st
+++ b/src/Famix-Queries-Tests/FQComplementQueryTest.class.st
@@ -24,6 +24,7 @@ FQComplementQueryTest >> expectedResult [
 
 { #category : #running }
 FQComplementQueryTest >> newQuery [
+
 	parentQuery := FQBooleanQuery new property: #isInstanceSide.
 	^ self unConfiguredQuery beChildOf: parentQuery
 ]
@@ -55,6 +56,21 @@ FQComplementQueryTest >> testName [
 	self
 		assert: self unConfiguredQuery name
 		equals: 'Invalid Negation Query'
+]
+
+{ #category : #tests }
+FQComplementQueryTest >> testResult [
+
+	| tempQuery |
+	tempQuery := FQBooleanQuery property: #isStub.
+	tempQuery beChildOf: self newParentQuery.
+	query queryToNegate: tempQuery.
+
+	self assertEmpty: tempQuery result.
+	"Since the result of the query to negate is empty, the complement query should contain the complement of empty which is all. So, it is the same as the result of the root query"
+	self
+		assertCollection: query result
+		hasSameElements: (query runOn: self newParentQuery result)
 ]
 
 { #category : #'tests - running' }

--- a/src/Famix-Queries-Tests/FQNAryQueryTest.class.st
+++ b/src/Famix-Queries-Tests/FQNAryQueryTest.class.st
@@ -39,15 +39,15 @@ FQNAryQueryTest >> newNavigationParent [
 
 { #category : #running }
 FQNAryQueryTest >> newQuery [
+
 	"This gives different, non-empty results for each binary query"
 
 	| firstParentQuery secondParentQuery |
 	firstParentQuery := self newNavigationParent.
 	secondParentQuery := self newTypeParent.
-	^ self unConfiguredQuery
-		beChildOf:
-			{firstParentQuery.
-			secondParentQuery}
+	^ self unConfiguredQuery subqueries: { 
+			  firstParentQuery.
+			  secondParentQuery }
 ]
 
 { #category : #parents }
@@ -76,49 +76,11 @@ FQNAryQueryTest >> secondParentOfQuery [
 ]
 
 { #category : #tests }
-FQNAryQueryTest >> testBeChildOf [
-	| parents |
-	parents := {self newBooleanParent.
-	self newTypeParent}.
-	query := self unConfiguredQuery beChildOf: parents.
-
-	self assertCollection: query subqueries hasSameElements: parents.
-
-	self assert: (parents first children includes: query).
-	self assert: (parents second children includes: query)
-]
-
-{ #category : #tests }
 FQNAryQueryTest >> testIsValid [
-	self
-		deny:
-			(self unConfiguredQuery
-				beChildOf:
-					{self newTypeParent.
-					self newInvalidParent}) isValid
-]
 
-{ #category : #tests }
-FQNAryQueryTest >> testParentSequence [
-	"One generation"
-	self
-		assertCollection: query parentSequence
-		hasSameElements:
-			{self firstParentOfQuery.
-			self secondParentOfQuery.
-			query}.
-
-	"Two generations"
-	query subqueries first beChildOf: self newBooleanParent.
-	query subqueries second beChildOf: self newStringParent.
-	self
-		assertCollection: query parentSequence
-		hasSameElements:
-			{self firstParentOfQuery parent.
-			self firstParentOfQuery.
-			self secondParentOfQuery parent.
-			self secondParentOfQuery.
-			query}
+	self deny: (self unConfiguredQuery subqueries: { 
+				 self newTypeParent.
+				 self newInvalidParent }) isValid
 ]
 
 { #category : #tests }
@@ -150,4 +112,18 @@ FQNAryQueryTest >> testRunOn [
 		assertCollection:
 			(query runOn: self parentQueriesResult)
 		hasSameElements: self expectedResult
+]
+
+{ #category : #tests }
+FQNAryQueryTest >> testSubqueries [
+
+	| subqueries |
+	query := self unConfiguredQuery.
+	self assertEmpty: query subqueries.
+	subqueries := { 
+		              self newBooleanParent.
+		              self newTypeParent }.
+	query subqueries: subqueries.
+
+	self assertCollection: query subqueries hasSameElements: subqueries
 ]

--- a/src/Famix-Queries-Tests/FQTypeQueryTest.class.st
+++ b/src/Famix-Queries-Tests/FQTypeQueryTest.class.st
@@ -35,11 +35,6 @@ FQTypeQueryTest >> expectedResult [
 		asMooseGroup
 ]
 
-{ #category : #'instance creation' }
-FQTypeQueryTest >> newParentQuery [
-	^ FQRootQuery new result: helper modelExample
-]
-
 { #category : #running }
 FQTypeQueryTest >> newQuery [
 	^ self unConfiguredQuery

--- a/src/Famix-Queries-Tests/FQUnaryQueryTest.class.st
+++ b/src/Famix-Queries-Tests/FQUnaryQueryTest.class.st
@@ -11,6 +11,7 @@ FQUnaryQueryTest class >> isAbstract [
 
 { #category : #'instance creation' }
 FQUnaryQueryTest >> newParentQuery [
+
 	^ FQRootQuery new result: helper classes
 ]
 

--- a/src/Famix-Queries/FQAbstractQuery.class.st
+++ b/src/Famix-Queries/FQAbstractQuery.class.st
@@ -180,7 +180,9 @@ FQAbstractQuery >> resetResult [
 
 { #category : #running }
 FQAbstractQuery >> result [
-	^ result ifNil: [ result := self computeResult ]
+
+	result ifNil: [ self computeResult ].
+	^ result
 ]
 
 { #category : #running }

--- a/src/Famix-Queries/FQAbstractQuery.class.st
+++ b/src/Famix-Queries/FQAbstractQuery.class.st
@@ -37,6 +37,12 @@ Class {
 	#category : #'Famix-Queries-Core'
 }
 
+{ #category : #testing }
+FQAbstractQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
+
+	^ false
+]
+
 { #category : #accessing }
 FQAbstractQuery class >> label [
 	^ self subclassResponsibility
@@ -53,13 +59,6 @@ FQAbstractQuery >> & anotherQuery [
 ]
 
 { #category : #composition }
-FQAbstractQuery >> --> aChildQuery [
-	^ aChildQuery
-		beChildOf: self;
-		yourself
-]
-
-{ #category : #composition }
 FQAbstractQuery >> \ anotherQuery [
 
 	^ self subtraction: anotherQuery
@@ -68,16 +67,6 @@ FQAbstractQuery >> \ anotherQuery [
 { #category : #adding }
 FQAbstractQuery >> addChild: aQuery [
 	children add: aQuery
-]
-
-{ #category : #adding }
-FQAbstractQuery >> addToParentsSequence: sequence [
-	self subclassResponsibility
-]
-
-{ #category : #adding }
-FQAbstractQuery >> beChildOf: aQueryOrCollection [
-	self subclassResponsibility
 ]
 
 { #category : #printing }
@@ -112,13 +101,8 @@ FQAbstractQuery >> displayOn: aStream [
 	^ self subclassResponsibility
 ]
 
-{ #category : #testing }
-FQAbstractQuery >> hasNoParent [
-	^ self subclassResponsibility
-]
-
-{ #category : #comparing }
-FQAbstractQuery >> hasSameParentsAs: aQuery [
+{ #category : #accessing }
+FQAbstractQuery >> hasSameParametersAs: arg1 [ 
 	^ self subclassResponsibility
 ]
 
@@ -130,10 +114,10 @@ FQAbstractQuery >> initialize [
 
 { #category : #composition }
 FQAbstractQuery >> intersection: anotherQuery [
-	^ FQIntersectionQuery new
-		beChildOf:
-			{self.
-			anotherQuery}
+
+	^ FQIntersectionQuery new subqueries: { 
+			  self.
+			  anotherQuery }
 ]
 
 { #category : #printing }
@@ -212,24 +196,25 @@ FQAbstractQuery >> storeOn: aStream [
 ]
 
 { #category : #printing }
-FQAbstractQuery >> storeOn: aStream withParentsIn: queries [
+FQAbstractQuery >> storeWithParentsOn: aStream [
+
 	self subclassResponsibility
 ]
 
 { #category : #composition }
 FQAbstractQuery >> subtraction: anotherQuery [
 
-	^ FQSubtractionQuery new beChildOf: { 
+	^ FQSubtractionQuery new subqueries: { 
 			  self.
 			  anotherQuery }
 ]
 
 { #category : #composition }
 FQAbstractQuery >> union: anotherQuery [
-	^ FQUnionQuery new
-		beChildOf:
-			{self.
-			anotherQuery}
+
+	^ FQUnionQuery new subqueries: { 
+			  self.
+			  anotherQuery }
 ]
 
 { #category : #composition }

--- a/src/Famix-Queries/FQBooleanQuery.class.st
+++ b/src/Famix-Queries/FQBooleanQuery.class.st
@@ -39,6 +39,12 @@ FQBooleanQuery class >> comparators [
 	^#()
 ]
 
+{ #category : #testing }
+FQBooleanQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
+
+	^ true
+]
+
 { #category : #accessing }
 FQBooleanQuery class >> label [
 	^ 'Boolean Query'

--- a/src/Famix-Queries/FQComplementQuery.class.st
+++ b/src/Famix-Queries/FQComplementQuery.class.st
@@ -51,11 +51,9 @@ FQComplementQuery >> beDefaultForParent [
 { #category : #running }
 FQComplementQuery >> computeResult [
 
-	self isValid ifFalse: [ ^ MooseGroup new ].
-
-	^ queryToNegate isRootQuery
-		  ifTrue: [ self runOn: queryToNegate result ]
-		  ifFalse: [ self runOn: queryToNegate parent result ]
+	^ result := self isValid
+		            ifTrue: [ self runOn: queryToNegate parent result ]
+		            ifFalse: [ MooseGroup new ]
 ]
 
 { #category : #printing }

--- a/src/Famix-Queries/FQComplementQuery.class.st
+++ b/src/Famix-Queries/FQComplementQuery.class.st
@@ -21,6 +21,12 @@ FQComplementQuery class >> defaultForParent: aQuery [
 	^ self queryToNegate: aQuery
 ]
 
+{ #category : #testing }
+FQComplementQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
+
+	^ numberOfQueriesInPresenter > 0
+]
+
 { #category : #accessing }
 FQComplementQuery class >> label [
 

--- a/src/Famix-Queries/FQIntersectionQuery.class.st
+++ b/src/Famix-Queries/FQIntersectionQuery.class.st
@@ -10,6 +10,12 @@ Class {
 }
 
 { #category : #testing }
+FQIntersectionQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
+
+	^ numberOfQueriesInPresenter > 1
+]
+
+{ #category : #testing }
 FQIntersectionQuery class >> isCommutative [
 	^ true
 ]

--- a/src/Famix-Queries/FQNaryQuery.class.st
+++ b/src/Famix-Queries/FQNaryQuery.class.st
@@ -30,18 +30,20 @@ FQNAryQuery class >> isCommutative [
 ]
 
 { #category : #accessing }
-FQNAryQuery class >> subqueries: twoQueries [
+FQNAryQuery class >> subqueries: aCollection [
 
 	^ self new
-		  subqueries: twoQueries;
+		  subqueries: aCollection;
 		  yourself
 ]
 
 { #category : #running }
 FQNAryQuery >> computeResult [
-	self isValid
-		ifFalse: [ ^ MooseGroup new ].
-	^ self runOn: (self subqueries collect: #result)
+
+	^ result := self isValid
+		            ifTrue: [ 
+		            self runOn: (self subqueries collect: #result) ]
+		            ifFalse: [ MooseGroup new ]
 ]
 
 { #category : #printing }

--- a/src/Famix-Queries/FQNaryQuery.class.st
+++ b/src/Famix-Queries/FQNaryQuery.class.st
@@ -19,6 +19,12 @@ FQNAryQuery class >> availableCombinations [
 ]
 
 { #category : #testing }
+FQNAryQuery class >> isAbstract [
+
+	^ self == FQNAryQuery
+]
+
+{ #category : #testing }
 FQNAryQuery class >> isCommutative [
 	^ self subclassResponsibility
 ]
@@ -29,25 +35,6 @@ FQNAryQuery class >> subqueries: twoQueries [
 	^ self new
 		  subqueries: twoQueries;
 		  yourself
-]
-
-{ #category : #adding }
-FQNAryQuery >> addToParentsSequence: sequence [
-	self flag: #FQImprove , 'Need for a specific order ?'.
-	self subqueries do: [ :parent | parent addToParentsSequence: sequence ].
-	(sequence includes: self)
-		ifTrue: [ children
-				do:
-					[ :child | (sequence detect: [ :query | query = self ]) addChild: child ] ]
-		ifFalse: [ sequence addLast: self ].
-	^ sequence
-]
-
-{ #category : #adding }
-FQNAryQuery >> beChildOf: parentQueries [
-	self subqueries ifNotEmpty: [ self prepareRemoval ].
-	self subqueries: parentQueries.
-	parentQueries do: [ :newParent | newParent addChild: self ]
 ]
 
 { #category : #running }
@@ -68,11 +55,6 @@ FQNAryQuery >> displayOn: aStream [
 	aStream << ')'
 ]
 
-{ #category : #testing }
-FQNAryQuery >> hasNoParent [
-	^ self subqueries isEmpty
-]
-
 { #category : #comparing }
 FQNAryQuery >> hasSameParametersAs: aQuery [
 	self subqueries
@@ -84,7 +66,8 @@ FQNAryQuery >> hasSameParametersAs: aQuery [
 ]
 
 { #category : #comparing }
-FQNAryQuery >> hasSameParentsAs: aQuery [
+FQNAryQuery >> hasSameSubqueriesAs: aQuery [
+
 	^ self subqueries = aQuery subqueries
 ]
 
@@ -96,14 +79,21 @@ FQNAryQuery >> initialize [
 
 { #category : #testing }
 FQNAryQuery >> isValid [
-	^ self subqueries isNotEmpty
-		and: [ self subqueries
-				allSatisfy: [ :parent | parent isNotNil and: [ parent isValid ] ] ]
+
+	^ self subqueries isNotEmpty and: [ 
+		  self subqueries allSatisfy: [ :subquery | 
+			  subquery isNotNil and: [ subquery isValid ] ] ]
 ]
 
 { #category : #printing }
 FQNAryQuery >> operator [
 	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+FQNAryQuery >> parentSequence [
+
+	^ #(  )
 ]
 
 { #category : #printing }
@@ -118,14 +108,12 @@ FQNAryQuery >> storeOn: aStream [
 ]
 
 { #category : #printing }
-FQNAryQuery >> storeOn: aStream withParentsIn: queries [
-
-	(queries includesAll: subqueries) ifFalse: [ ^ self storeOn: aStream ].
+FQNAryQuery >> storeWithParentsOn: aStream [
 
 	self subqueries
 		do: [ :subquery | 
 			aStream << '('.
-			subquery storeOn: aStream withParentsIn: queries.
+			subquery storeWithParentsOn: aStream.
 			aStream << ')' ]
 		separatedBy: [ aStream << ' ' << self operator << ' ' ]
 ]

--- a/src/Famix-Queries/FQNavigationQuery.class.st
+++ b/src/Famix-Queries/FQNavigationQuery.class.st
@@ -68,6 +68,12 @@ FQNavigationQuery class >> incoming [
 		yourself
 ]
 
+{ #category : #testing }
+FQNavigationQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
+
+	^ true
+]
+
 { #category : #accessing }
 FQNavigationQuery class >> label [
 	^ 'Navigation Query'

--- a/src/Famix-Queries/FQNumericQuery.class.st
+++ b/src/Famix-Queries/FQNumericQuery.class.st
@@ -55,6 +55,12 @@ FQNumericQuery class >> defaultValueToCompare [
 	^ 0
 ]
 
+{ #category : #testing }
+FQNumericQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
+
+	^ true
+]
+
 { #category : #accessing }
 FQNumericQuery class >> label [
 	^ 'Numeric Query'

--- a/src/Famix-Queries/FQResultSizeQuery.class.st
+++ b/src/Famix-Queries/FQResultSizeQuery.class.st
@@ -23,6 +23,12 @@ FQResultSizeQuery class >> innerQuery: aQuery comparator: aComparingSymbol value
 		yourself
 ]
 
+{ #category : #testing }
+FQResultSizeQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
+
+	^ numberOfQueriesInPresenter > 0
+]
+
 { #category : #accessing }
 FQResultSizeQuery class >> label [
 	^ 'Result Size Query'

--- a/src/Famix-Queries/FQScopeQuery.class.st
+++ b/src/Famix-Queries/FQScopeQuery.class.st
@@ -66,6 +66,12 @@ FQScopeQuery class >> downTo: aScope [
 		yourself
 ]
 
+{ #category : #testing }
+FQScopeQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
+
+	^ true
+]
+
 { #category : #accessing }
 FQScopeQuery class >> label [
 	^ 'Scope Query'

--- a/src/Famix-Queries/FQStringQuery.class.st
+++ b/src/Famix-Queries/FQStringQuery.class.st
@@ -55,6 +55,12 @@ FQStringQuery class >> defaultValueToCompare [
 	^ ''
 ]
 
+{ #category : #testing }
+FQStringQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
+
+	^ true
+]
+
 { #category : #accessing }
 FQStringQuery class >> label [
 	^ 'String Query'

--- a/src/Famix-Queries/FQSubtractionQuery.class.st
+++ b/src/Famix-Queries/FQSubtractionQuery.class.st
@@ -10,6 +10,12 @@ Class {
 }
 
 { #category : #testing }
+FQSubtractionQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
+
+	^ numberOfQueriesInPresenter > 1
+]
+
+{ #category : #testing }
 FQSubtractionQuery class >> isCommutative [
 	^ false
 ]

--- a/src/Famix-Queries/FQTypeQuery.class.st
+++ b/src/Famix-Queries/FQTypeQuery.class.st
@@ -157,10 +157,12 @@ FQTypeQuery >> runOn: aMooseGroup [
 
 { #category : #printing }
 FQTypeQuery >> storeOn: aStream [
+
 	aStream << self className << ' types: {'.
-	self isValid
-		ifTrue: [ self types allButLastDo: [ :type | aStream << type name << '. ' ].
-			aStream << self types last name ].
+	self isValid ifTrue: [ 
+		self types
+			do: [ :type | aStream << type name ]
+			separatedBy: [ aStream << '. ' ] ].
 	aStream << $}
 ]
 

--- a/src/Famix-Queries/FQTypeQuery.class.st
+++ b/src/Famix-Queries/FQTypeQuery.class.st
@@ -47,6 +47,12 @@ Class {
 	#category : #'Famix-Queries-Queries-Unary'
 }
 
+{ #category : #testing }
+FQTypeQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
+
+	^ true
+]
+
 { #category : #'instance creation' }
 FQTypeQuery class >> label [
 	^ 'Type Query'

--- a/src/Famix-Queries/FQUnaryQuery.class.st
+++ b/src/Famix-Queries/FQUnaryQuery.class.st
@@ -32,6 +32,13 @@ FQUnaryQuery class >> stringForClass: aClass [
 		last asEnglishPlural
 ]
 
+{ #category : #composition }
+FQUnaryQuery >> --> aChildQuery [
+	^ aChildQuery
+		beChildOf: self;
+		yourself
+]
+
 { #category : #adding }
 FQUnaryQuery >> addToParentsSequence: sequence [
 	parent ifNotNil: [ parent addToParentsSequence: sequence ].
@@ -123,11 +130,11 @@ FQUnaryQuery >> resetParent [
 ]
 
 { #category : #printing }
-FQUnaryQuery >> storeOn: aStream withParentsIn: queries [
-	(parent isNil
-		or: [ parent isRootQuery or: [ (queries includes: parent) not ] ])
-		ifFalse: [ parent storeOn: aStream withParentsIn: queries.
-			aStream << ' --> ' ].
+FQUnaryQuery >> storeWithParentsOn: aStream [
+
+	(parent isNil or: [ parent isRootQuery ]) ifFalse: [ 
+		parent storeWithParentsOn: aStream.
+		aStream << ' --> ' ].
 	aStream << '('.
 	self storeOn: aStream.
 	aStream << ')'

--- a/src/Famix-Queries/FQUnaryQuery.class.st
+++ b/src/Famix-Queries/FQUnaryQuery.class.st
@@ -65,9 +65,9 @@ FQUnaryQuery >> beDefaultForParent [
 { #category : #running }
 FQUnaryQuery >> computeResult [
 
-	self isValid ifFalse: [ ^ MooseGroup new ].
-
-	^ self runOn: parent result
+	^ result := self isValid
+		            ifTrue: [ self runOn: parent result ]
+		            ifFalse: [ MooseGroup new ]
 ]
 
 { #category : #printing }

--- a/src/Famix-Queries/FQUnionQuery.class.st
+++ b/src/Famix-Queries/FQUnionQuery.class.st
@@ -10,6 +10,12 @@ Class {
 }
 
 { #category : #testing }
+FQUnionQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
+
+	^ numberOfQueriesInPresenter > 1
+]
+
+{ #category : #testing }
 FQUnionQuery class >> isCommutative [
 	^ true
 ]


### PR DESCRIPTION
- Remoeved all parent references in NAry queries
- Nos the complement query cannot be used with a root query because ir doesn't have sence
- Refactors in general