### PR TITLE
47 clean queries

### DIFF
--- a/src/Famix-Queries-Tests/FQComplementQueryTest.class.st
+++ b/src/Famix-Queries-Tests/FQComplementQueryTest.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FQComplementQueryTest,
-	#superclass : #FQUnaryQueryTest,
+	#superclass : #FQAbstractQueryTest,
 	#instVars : [
-		'parentQuery'
+		'queryToNegate'
 	],
 	#category : #'Famix-Queries-Tests-Unary'
 }
@@ -19,14 +19,21 @@ FQComplementQueryTest >> expectedPrintOnString [
 
 { #category : #tests }
 FQComplementQueryTest >> expectedResult [
-	^ helper classes copyWithoutAll: (parentQuery runOn: helper classes)
+
+	^ helper classes copyWithoutAll: (queryToNegate runOn: helper classes)
 ]
 
 { #category : #running }
 FQComplementQueryTest >> newQuery [
 
-	parentQuery := FQBooleanQuery new property: #isInstanceSide.
-	^ self unConfiguredQuery beChildOf: parentQuery
+	queryToNegate := FQBooleanQuery new property: #isInstanceSide.
+	^ self unConfiguredQuery queryToNegate: queryToNegate
+]
+
+{ #category : #tests }
+FQComplementQueryTest >> newQueryToNegate [
+
+	^ FQRootQuery new result: helper classes
 ]
 
 { #category : #'tests - printing' }
@@ -37,16 +44,17 @@ FQComplementQueryTest >> testDisplayOn [
 			(String
 				streamContents: [ :s | 
 					s << 'aMooseGroup copyWithoutAll: ('.
-					parentQuery displayOn: s.
+					queryToNegate displayOn: s.
 					s << ')' ])
 ]
 
 { #category : #tests }
 FQComplementQueryTest >> testIsValid [
+
 	super testIsValid.
 	query prepareRemoval.
 	self deny: query isValid.
-	query beChildOf: FQBooleanQuery new.
+	query queryToNegate: FQBooleanQuery new.
 	self deny: query isValid
 ]
 
@@ -59,18 +67,47 @@ FQComplementQueryTest >> testName [
 ]
 
 { #category : #tests }
+FQComplementQueryTest >> testParentSequence [
+
+	self assert: query parentSequence equals: #(  )
+]
+
+{ #category : #tests }
+FQComplementQueryTest >> testPrepareRemoval [
+
+	| tempQueryToNegate |
+	tempQueryToNegate := self differentTypeOfQuery.
+	query queryToNegate: tempQueryToNegate.
+
+	query prepareRemoval.
+	self assert: query queryToNegate isNil
+]
+
+{ #category : #tests }
+FQComplementQueryTest >> testQueryToNegate [
+
+	| tmpQueryToNegate |
+	tmpQueryToNegate := self differentTypeOfQuery.
+	query queryToNegate: tmpQueryToNegate.
+	self assert: query queryToNegate equals: tmpQueryToNegate
+]
+
+{ #category : #tests }
 FQComplementQueryTest >> testResult [
 
 	| tempQuery |
 	tempQuery := FQBooleanQuery property: #isStub.
-	tempQuery beChildOf: self newParentQuery.
+	tempQuery beChildOf: self newQueryToNegate.
 	query queryToNegate: tempQuery.
 
 	self assertEmpty: tempQuery result.
 	"Since the result of the query to negate is empty, the complement query should contain the complement of empty which is all. So, it is the same as the result of the root query"
 	self
 		assertCollection: query result
-		hasSameElements: (query runOn: self newParentQuery result)
+		hasSameElements: (query runOn: self newQueryToNegate result).
+	self
+		assertCollection: query result
+		hasSameElements: self newQueryToNegate result
 ]
 
 { #category : #'tests - running' }
@@ -83,9 +120,10 @@ FQComplementQueryTest >> testRunOn [
 
 { #category : #'tests - printing' }
 FQComplementQueryTest >> testStoreOn [
+
 	| generatedQuery |
-	generatedQuery := self
-		evaluate: (String streamContents: [ :s | query storeOn: s ]).
+	generatedQuery := self evaluate:
+		                  (String streamContents: [ :s | query storeOn: s ]).
 	self assert: generatedQuery class identicalTo: self actualClass.
 	self assert: (generatedQuery hasSameParametersAs: query)
 ]

--- a/src/Famix-Queries-Tests/FQNAryQueryTest.class.st
+++ b/src/Famix-Queries-Tests/FQNAryQueryTest.class.st
@@ -84,6 +84,12 @@ FQNAryQueryTest >> testIsValid [
 ]
 
 { #category : #tests }
+FQNAryQueryTest >> testParentSequence [
+
+	self assert: query parentSequence equals: #(  )
+]
+
+{ #category : #tests }
 FQNAryQueryTest >> testParents [
 	| newParents previousParents |
 	newParents := {self newBooleanParent.

--- a/src/Famix-Queries-Tests/FQUnaryQueryTest.class.st
+++ b/src/Famix-Queries-Tests/FQUnaryQueryTest.class.st
@@ -53,25 +53,22 @@ FQUnaryQueryTest >> testParent [
 
 { #category : #tests }
 FQUnaryQueryTest >> testParentSequence [
-	query isRootQuery
-		ifTrue: [ self skip ].
-		
+
+	query isRootQuery ifTrue: [ self skip ].
+
 	"One generation"
 	query beChildOf: self differentTypeOfQuery.
 	self
 		assertCollection: query parentSequence
-		hasSameElements:
-			{query parent.
-			query}.
+		hasSameElements: { query parent }.
 
 	"Two generations"
 	query parent beChildOf: self newParentQuery.
 	self
-		assertCollection: query parentSequence
-		hasSameElements:
-			{query parent parent.
-			query parent.
-			query}
+	assertCollection: query parentSequence
+	hasSameElements: { 
+			query parent parent.
+			query parent }
 ]
 
 { #category : #tests }

--- a/src/Famix-Queries/FQAbstractQuery.class.st
+++ b/src/Famix-Queries/FQAbstractQuery.class.st
@@ -37,6 +37,21 @@ Class {
 	#category : #'Famix-Queries-Core'
 }
 
+{ #category : #testing }
+FQAbstractQuery class >> isComplementQuery [
+	^ false
+]
+
+{ #category : #testing }
+FQAbstractQuery class >> isNAryQuery [
+	^ false
+]
+
+{ #category : #testing }
+FQAbstractQuery class >> isUnaryQuery [
+	^ false
+]
+
 { #category : #accessing }
 FQAbstractQuery class >> label [
 	^ self subclassResponsibility
@@ -120,7 +135,22 @@ FQAbstractQuery >> invalidDefaultName [
 ]
 
 { #category : #testing }
+FQAbstractQuery >> isComplementQuery [
+	^ false
+]
+
+{ #category : #testing }
+FQAbstractQuery >> isNAryQuery [
+	^ false
+]
+
+{ #category : #testing }
 FQAbstractQuery >> isRootQuery [
+	^ false
+]
+
+{ #category : #testing }
+FQAbstractQuery >> isUnaryQuery [
 	^ false
 ]
 

--- a/src/Famix-Queries/FQAbstractQuery.class.st
+++ b/src/Famix-Queries/FQAbstractQuery.class.st
@@ -141,10 +141,8 @@ FQAbstractQuery >> name: aString [
 
 { #category : #accessing }
 FQAbstractQuery >> parentSequence [
-	| sequence |
-	sequence := OrderedCollection new.
-	self addToParentsSequence: sequence.
-	^ sequence
+
+	self subclassResponsibility
 ]
 
 { #category : #removing }

--- a/src/Famix-Queries/FQComplementQuery.class.st
+++ b/src/Famix-Queries/FQComplementQuery.class.st
@@ -12,12 +12,6 @@ Class {
 	#category : #'Famix-Queries-Complement-Query'
 }
 
-{ #category : #default }
-FQComplementQuery class >> defaultForParent: aQuery [
-
-	^ self queryToNegate: aQuery
-]
-
 { #category : #accessing }
 FQComplementQuery class >> label [
 

--- a/src/Famix-Queries/FQComplementQuery.class.st
+++ b/src/Famix-Queries/FQComplementQuery.class.st
@@ -1,18 +1,15 @@
 "
 A complement query can be seen as a ""negation"" query. In simple words, it returns the complement of the `queryToNegate` result.
 In order to do that, this query is instantiated with a query to negate. It takes `queryToNegate parent result`. This returns all the entities (`allEntities`). And then it does the substraction of the current result (`queryToNegate result`) with allEntities.
-This (`allEntities - queryToNegate result`) gives the complement of the current result.
-
-_Note: The `parent` instance variable, that is defined in `FQUnaryQuery`, is not used in this query. But, we set the value of parent variable as the same as `queryToNegate` value. This is for all the functionalities that are defined in the parent class (`FQUnaryQuery`) works without problem. Because the parent class uses the parent instance variable.
-But keep in mind that this query does not have a parent, only a queryToNegate._
+This (`allEntities - queryToNegate result`) gives the complement of the current result
 "
 Class {
 	#name : #FQComplementQuery,
-	#superclass : #FQUnaryQuery,
+	#superclass : #FQAbstractQuery,
 	#instVars : [
 		'queryToNegate'
 	],
-	#category : #'Famix-Queries-Queries-Unary'
+	#category : #'Famix-Queries-Complement-Query'
 }
 
 { #category : #default }
@@ -57,40 +54,49 @@ FQComplementQuery >> defaultName [
 ]
 
 { #category : #printing }
-FQComplementQuery >> displayOn: aStream with: aString [
-	aStream << 'aMooseGroup copyWithoutAll: ' << aString
+FQComplementQuery >> displayOn: aStream [
+
+	aStream << 'aMooseGroup copyWithoutAll: ' << $(.
+	queryToNegate displayOn: aStream.
+	aStream << $)
 ]
 
-{ #category : #comparing }
+{ #category : #accessing }
 FQComplementQuery >> hasSameParametersAs: aQuery [
 
-	^ aQuery parent hasSameParametersAs: queryToNegate
+	^ aQuery queryToNegate hasSameParametersAs: queryToNegate
 ]
 
 { #category : #testing }
 FQComplementQuery >> isValid [
 
-	| isParentValid isQuerytoNegateValid |
-	isParentValid := parent isNotNil and: [ parent isValid ].
-	isQuerytoNegateValid := queryToNegate isNotNil and: [ 
-		                        queryToNegate isValid ].
-	^ isParentValid and: [ isQuerytoNegateValid ]
+	^ queryToNegate isNotNil and: [ queryToNegate isValid ]
 ]
 
 { #category : #accessing }
-FQComplementQuery >> parent: aQuery [
+FQComplementQuery >> parentSequence [
 
-	"This method is overridden only for the purpose of using the queryToNegate instance variable instead of parent. The queryToNegate instance variable was created only for better readability. Does not add any functionality."
+	"This query has no parent"
 
-	parent := aQuery.
-	queryToNegate := aQuery
+	^ #(  )
+]
+
+{ #category : #removing }
+FQComplementQuery >> prepareRemoval [
+
+	queryToNegate := nil
+]
+
+{ #category : #accessing }
+FQComplementQuery >> queryToNegate [
+
+	^ queryToNegate
 ]
 
 { #category : #accessing }
 FQComplementQuery >> queryToNegate: aQuery [
 
-	queryToNegate := aQuery.
-	parent := aQuery
+	queryToNegate := aQuery
 ]
 
 { #category : #running }
@@ -109,7 +115,15 @@ FQComplementQuery >> runOn: allEntitiesMooseGroup [
 { #category : #printing }
 FQComplementQuery >> storeOn: aStream [
 
-	aStream << self className << ' new beChildOf: ('.
-	queryToNegate storeOn: aStream.
+	aStream << self className << ' queryToNegate: ('.
+	queryToNegate storeWithParentsOn: aStream.
 	aStream << $)
+]
+
+{ #category : #printing }
+FQComplementQuery >> storeWithParentsOn: aStream [
+
+	aStream << '('.
+	self storeOn: aStream.
+	aStream << ')'
 ]

--- a/src/Famix-Queries/FQComplementQuery.class.st
+++ b/src/Famix-Queries/FQComplementQuery.class.st
@@ -62,6 +62,12 @@ FQComplementQuery >> hasSameParametersAs: aQuery [
 ]
 
 { #category : #testing }
+FQComplementQuery >> isComplementQuery [
+
+	^ true
+]
+
+{ #category : #testing }
 FQComplementQuery >> isValid [
 
 	^ queryToNegate isNotNil and: [ queryToNegate isValid ]

--- a/src/Famix-Queries/FQNaryQuery.class.st
+++ b/src/Famix-Queries/FQNaryQuery.class.st
@@ -89,6 +89,7 @@ FQNAryQuery >> isValid [
 
 { #category : #printing }
 FQNAryQuery >> operator [
+
 	^ self subclassResponsibility
 ]
 
@@ -98,6 +99,12 @@ FQNAryQuery >> parentSequence [
 	"This query has no parent"
 
 	^ #(  )
+]
+
+{ #category : #removing }
+FQNAryQuery >> prepareRemoval [
+
+	subqueries := nil
 ]
 
 { #category : #printing }

--- a/src/Famix-Queries/FQNaryQuery.class.st
+++ b/src/Famix-Queries/FQNaryQuery.class.st
@@ -95,6 +95,8 @@ FQNAryQuery >> operator [
 { #category : #accessing }
 FQNAryQuery >> parentSequence [
 
+	"This query has no parent"
+
 	^ #(  )
 ]
 

--- a/src/Famix-Queries/FQNaryQuery.class.st
+++ b/src/Famix-Queries/FQNaryQuery.class.st
@@ -29,6 +29,12 @@ FQNAryQuery class >> isCommutative [
 	^ self subclassResponsibility
 ]
 
+{ #category : #testing }
+FQNAryQuery class >> isNAryQuery [
+
+	^ true
+]
+
 { #category : #accessing }
 FQNAryQuery class >> subqueries: aCollection [
 
@@ -77,6 +83,12 @@ FQNAryQuery >> hasSameSubqueriesAs: aQuery [
 FQNAryQuery >> initialize [
 	super initialize.
 	subqueries := OrderedCollection new
+]
+
+{ #category : #testing }
+FQNAryQuery >> isNAryQuery [
+
+	^ true
 ]
 
 { #category : #testing }

--- a/src/Famix-Queries/FQUnaryQuery.class.st
+++ b/src/Famix-Queries/FQUnaryQuery.class.st
@@ -41,11 +41,12 @@ FQUnaryQuery >> --> aChildQuery [
 
 { #category : #adding }
 FQUnaryQuery >> addToParentsSequence: sequence [
+
 	parent ifNotNil: [ parent addToParentsSequence: sequence ].
 	(sequence includes: self)
-		ifTrue: [ children
-				do:
-					[ :child | (sequence detect: [ :query | query = self ]) addChild: child ] ]
+		ifTrue: [ 
+			children do: [ :child | 
+				(sequence detect: [ :query | query = self ]) addChild: child ] ]
 		ifFalse: [ sequence addLast: self ].
 	^ sequence
 ]
@@ -114,6 +115,14 @@ FQUnaryQuery >> parentDisplayString [
 			aStream << $(.
 			parent displayOn: aStream.
 			aStream << $) ]
+]
+
+{ #category : #accessing }
+FQUnaryQuery >> parentSequence [
+	| sequence |
+	sequence := OrderedCollection new.
+	self addToParentsSequence: sequence.
+	^ sequence
 ]
 
 { #category : #removing }

--- a/src/Famix-Queries/FQUnaryQuery.class.st
+++ b/src/Famix-Queries/FQUnaryQuery.class.st
@@ -26,6 +26,12 @@ FQUnaryQuery class >> isAbstract [
 	^ self == FQUnaryQuery
 ]
 
+{ #category : #testing }
+FQUnaryQuery class >> isUnaryQuery [
+
+	^ true
+]
+
 { #category : #printing }
 FQUnaryQuery class >> stringForClass: aClass [
 	^ (aClass name piecesCutWhere: [ :char1 :char2 | char2 isUppercase ])
@@ -96,6 +102,11 @@ FQUnaryQuery >> hasSameParentsAs: aQuery [
 	^ parent = aQuery parent
 ]
 
+{ #category : #testing }
+FQUnaryQuery >> isUnaryQuery [
+	^ true
+]
+
 { #category : #accessing }
 FQUnaryQuery >> parent [
 	^ parent
@@ -119,9 +130,19 @@ FQUnaryQuery >> parentDisplayString [
 
 { #category : #accessing }
 FQUnaryQuery >> parentSequence [
-	| sequence |
+
+	| sequence parentToSequence |
 	sequence := OrderedCollection new.
-	self addToParentsSequence: sequence.
+	"self addToParentsSequence: sequence.
+	^ sequence"
+	parentToSequence := parent.
+	[ parentToSequence isNotNil ] whileTrue: [ 
+		sequence add: parentToSequence.
+		"Both the complement and the nary query don't have a parent"
+		parentToSequence isComplementQuery ifTrue: [ ^ sequence ].
+		parentToSequence isNAryQuery ifTrue: [ ^ sequence ].
+
+		parentToSequence := parentToSequence parent ].
 	^ sequence
 ]
 


### PR DESCRIPTION
Fixes #47 

- FQComplement query should not inherit from unary query because it SHOULD NOT have a parent.
- parent sequence should not raise any errors (now it raises an error if you call this method for a unary query that has a nary query as a parent)
- nary query should not have any parent but it can be the parent for other queries
