### PR TITLE
Introduce rawRunOn:

### DIFF
--- a/src/Famix-Queries-Tests/FQTypeQueryTest.class.st
+++ b/src/Famix-Queries-Tests/FQTypeQueryTest.class.st
@@ -11,7 +11,8 @@ FQTypeQueryTest >> actualClass [
 
 { #category : #'tests - available parameters' }
 FQTypeQueryTest >> allNamedEntitiesTypes [
-	^ (helper modelExample allUsing: FamixTNamedEntity) collect: #class
+
+	^ (helper modelExample rawAllUsing: FamixTNamedEntity) collect: #class
 ]
 
 { #category : #'tests - running' }

--- a/src/Famix-Queries/FQAbstractQuery.class.st
+++ b/src/Famix-Queries/FQAbstractQuery.class.st
@@ -203,6 +203,13 @@ FQAbstractQuery >> printOn: aStream [
 	aStream << Character space << (self name join: '()')
 ]
 
+{ #category : #running }
+FQAbstractQuery >> rawRunOn: aMooseGroup [
+	"I should run myself on the MooseGroup as parameter and return a new collection with my result. This collection will then be casted as a MooseGroup by #runOn:"
+
+	^ self subclassResponsibility
+]
+
 { #category : #removing }
 FQAbstractQuery >> removeChild: aQuery [
 	children remove: aQuery
@@ -225,7 +232,7 @@ FQAbstractQuery >> result [
 FQAbstractQuery >> runOn: aMooseGroup [
 	"I should run myself on the MooseGroup as parameter and return a new MooseGroup with my result."
 
-	^ self subclassResponsibility
+	^ (self rawRunOn: aMooseGroup) asMooseGroup
 ]
 
 { #category : #printing }

--- a/src/Famix-Queries/FQCollectScriptQuery.class.st
+++ b/src/Famix-Queries/FQCollectScriptQuery.class.st
@@ -22,13 +22,13 @@ FQCollectScriptQuery >> defaultName [
 ]
 
 { #category : #running }
-FQCollectScriptQuery >> runOn: aMooseGroup [
-	^((aMooseGroup allUsing: TEntityMetaLevelDependency)
-		   inject: Set new
-		   into: [ :res :entity || collected |
-				collected := script value: entity.
-				collected isCollection
-				ifTrue: [ res addAll: collected ]
-				ifFalse: [ res add: collected ].
-			   res ]) asMooseGroup
+FQCollectScriptQuery >> rawRunOn: aMooseGroup [
+
+	^ (aMooseGroup rawAllUsing: TEntityMetaLevelDependency) inject: Set new into: [ :res :entity |
+		  | collected |
+		  collected := script value: entity.
+		  collected isCollection
+			  ifTrue: [ res addAll: collected ]
+			  ifFalse: [ res add: collected ].
+		  res ]
 ]

--- a/src/Famix-Queries/FQComplementQuery.class.st
+++ b/src/Famix-Queries/FQComplementQuery.class.st
@@ -100,16 +100,12 @@ FQComplementQuery >> queryToNegate: aQuery [
 ]
 
 { #category : #running }
-FQComplementQuery >> runOn: allEntitiesMooseGroup [
-
-	"^ MooseGroup withAll:
-		  (allEntitiesMooseGroup copyWithoutAll: (queryToNegate runOn: allEntitiesMooseGroup))"
+FQComplementQuery >> rawRunOn: allEntitiesMooseGroup [
 
 	| newItems |
 	newItems := allEntitiesMooseGroup asSet.
-	newItems removeAllFoundIn:
-		(queryToNegate runOn: allEntitiesMooseGroup).
-	^ MooseGroup withAll: newItems
+	newItems removeAllFoundIn: (queryToNegate runOn: allEntitiesMooseGroup).
+	^ newItems
 ]
 
 { #category : #printing }

--- a/src/Famix-Queries/FQIntersectionQuery.class.st
+++ b/src/Famix-Queries/FQIntersectionQuery.class.st
@@ -31,7 +31,7 @@ FQIntersectionQuery >> operator [
 ]
 
 { #category : #running }
-FQIntersectionQuery >> runOn: mooseGroups [
+FQIntersectionQuery >> rawRunOn: mooseGroups [
 
 	^ mooseGroups fold: [ :a :b | a intersection: b ]
 ]

--- a/src/Famix-Queries/FQNavigationQuery.class.st
+++ b/src/Famix-Queries/FQNavigationQuery.class.st
@@ -235,6 +235,14 @@ FQNavigationQuery >> isValid [
 										allSatisfy: [ :assoc | self associationsIsValid: assoc ] ] ] ] ]
 ]
 
+{ #category : #running }
+FQNavigationQuery >> rawRunOn: aMooseGroup [
+
+	^ (aMooseGroup rawAllUsing: TEntityMetaLevelDependency) inject: Set new into: [ :res :entity |
+		  res addAll: (self directionStrategy query: entity with: self associationStrategy).
+		  res ]
+]
+
 { #category : #'adding - removing' }
 FQNavigationQuery >> removeAssociation: anAssociation [
 	self
@@ -252,19 +260,6 @@ FQNavigationQuery >> resetAndChangeDirection: aDirectionStrategy [
 	directionStrategy := aDirectionStrategy.
 	self associationStrategy: FQNavigationAssociations new.
 	self flag: #FQTest
-]
-
-{ #category : #running }
-FQNavigationQuery >> runOn: aMooseGroup [
-
-	^ ((aMooseGroup allUsing: TEntityMetaLevelDependency)
-		   inject: Set new
-		   into: [ :res :entity | 
-			   res addAll:
-				   (self directionStrategy
-					    query: entity
-					    with: self associationStrategy).
-			   res ]) asMooseGroup
 ]
 
 { #category : #printing }

--- a/src/Famix-Queries/FQNullQuery.class.st
+++ b/src/Famix-Queries/FQNullQuery.class.st
@@ -48,9 +48,9 @@ FQNullQuery >> prepareRemoval [
 ]
 
 { #category : #running }
-FQNullQuery >> runOn: aMooseGroup [
+FQNullQuery >> rawRunOn: aMooseGroup [
 
-	^ #(  ) asMooseGroup
+	^ #(  )
 ]
 
 { #category : #printing }

--- a/src/Famix-Queries/FQPropertyQuery.class.st
+++ b/src/Famix-Queries/FQPropertyQuery.class.st
@@ -173,7 +173,7 @@ FQPropertyQuery >> property: anObject [
 ]
 
 { #category : #running }
-FQPropertyQuery >> runOn: aMooseGroup [
+FQPropertyQuery >> rawRunOn: aMooseGroup [
 	self flag: #FQImprove , 'This false on error is not optimal'.
 
 	^ aMooseGroup

--- a/src/Famix-Queries/FQRelationQuery.class.st
+++ b/src/Famix-Queries/FQRelationQuery.class.st
@@ -100,6 +100,14 @@ FQRelationQuery >> isValid [
 	^ relationName isSymbol
 ]
 
+{ #category : #running }
+FQRelationQuery >> rawRunOn: aMooseGroup [
+
+	^ (aMooseGroup rawAllUsing: TEntityMetaLevelDependency) inject: Set new into: [ :res :entity |
+		  res addAll: (entity query relations named: self relationName).
+		  res ]
+]
+
 { #category : #accessing }
 FQRelationQuery >> relationName [
 
@@ -111,16 +119,6 @@ FQRelationQuery >> relationName: aSymbol [
 
 	relationName := aSymbol.
 	self resetResult
-]
-
-{ #category : #running }
-FQRelationQuery >> runOn: aMooseGroup [
-
-	^ ((aMooseGroup allUsing: TEntityMetaLevelDependency)
-		   inject: Set new
-		   into: [ :res :entity | 
-			   res addAll: (entity query relations named: self relationName).
-			   res ]) asMooseGroup
 ]
 
 { #category : #printing }

--- a/src/Famix-Queries/FQResultSizeQuery.class.st
+++ b/src/Famix-Queries/FQResultSizeQuery.class.st
@@ -104,12 +104,9 @@ FQResultSizeQuery >> isValid [
 ]
 
 { #category : #running }
-FQResultSizeQuery >> runOn: aMooseGroup [
+FQResultSizeQuery >> rawRunOn: aMooseGroup [
 
-	^ aMooseGroup select: [ :entity | 
-		  (innerQuery runOn: entity asMooseGroup) size
-			  perform: comparator
-			  with: valueToCompare ]
+	^ aMooseGroup select: [ :entity | (innerQuery runOn: entity asMooseGroup) size perform: comparator with: valueToCompare ]
 ]
 
 { #category : #printing }

--- a/src/Famix-Queries/FQRootQuery.class.st
+++ b/src/Famix-Queries/FQRootQuery.class.st
@@ -59,14 +59,14 @@ FQRootQuery >> isValid [
 	^ result isKindOf: MooseGroup
 ]
 
+{ #category : #running }
+FQRootQuery >> rawRunOn: aMooseGroup [
+	^ aMooseGroup
+]
+
 { #category : #accessing }
 FQRootQuery >> result: aMooseGroup [
 	result := aMooseGroup
-]
-
-{ #category : #running }
-FQRootQuery >> runOn: aMooseGroup [
-	^ aMooseGroup
 ]
 
 { #category : #printing }

--- a/src/Famix-Queries/FQScopeQuery.class.st
+++ b/src/Famix-Queries/FQScopeQuery.class.st
@@ -182,6 +182,14 @@ FQScopeQuery >> isValid [
 				and: [ self scopeIsValid: self scope ] ]
 ]
 
+{ #category : #running }
+FQScopeQuery >> rawRunOn: aMooseGroup [
+
+	^ (aMooseGroup rawAllUsing: TEntityMetaLevelDependency) inject: Set new into: [ :res :entity |
+		  res addAll: (self directionStrategy scope: self scope recursively: recursive on: entity).
+		  res ]
+]
+
 { #category : #accessing }
 FQScopeQuery >> recursive [
 
@@ -213,17 +221,6 @@ FQScopeQuery >> resetAndChangeDirection: aDirectionStrategyClass [
 { #category : #reset }
 FQScopeQuery >> resetScope [
 	scope := nil
-]
-
-{ #category : #running }
-FQScopeQuery >> runOn: aMooseGroup [
-
-	^ ((aMooseGroup allUsing: TEntityMetaLevelDependency)
-		   inject: Set new
-		   into: [ :res :entity | 
-			   res addAll:
-				   (self directionStrategy scope: self scope recursively: recursive on: entity).
-			   res ]) asMooseGroup
 ]
 
 { #category : #accessing }

--- a/src/Famix-Queries/FQSelectScriptQuery.class.st
+++ b/src/Famix-Queries/FQSelectScriptQuery.class.st
@@ -22,7 +22,7 @@ FQSelectScriptQuery >> defaultName [
 ]
 
 { #category : #running }
-FQSelectScriptQuery >> runOn: aMooseGroup [
+FQSelectScriptQuery >> rawRunOn: aMooseGroup [
 	"I should run myself on the MooseGroup as parameter and return a new MooseGroup with my result."
 
 	^ aMooseGroup select: script

--- a/src/Famix-Queries/FQSubtractionQuery.class.st
+++ b/src/Famix-Queries/FQSubtractionQuery.class.st
@@ -30,14 +30,14 @@ FQSubtractionQuery >> operator [
 	^ $\
 ]
 
+{ #category : #running }
+FQSubtractionQuery >> rawRunOn: mooseGroups [
+
+	^ mooseGroups fold: [ :a :b | a difference: b ]
+]
+
 { #category : #reversing }
 FQSubtractionQuery >> reverseParents [
 	self subqueries: self subqueries reverse.
 	self resetResult
-]
-
-{ #category : #running }
-FQSubtractionQuery >> runOn: mooseGroups [
-
-	^ mooseGroups fold: [ :a :b | a difference: b ]
 ]

--- a/src/Famix-Queries/FQTaggedEntityQuery.class.st
+++ b/src/Famix-Queries/FQTaggedEntityQuery.class.st
@@ -108,13 +108,9 @@ FQTaggedEntityQuery >> isValid [
 ]
 
 { #category : #running }
-FQTaggedEntityQuery >> runOn: aMooseGroup [
+FQTaggedEntityQuery >> rawRunOn: aMooseGroup [
 
-	"I should run myself on the MooseGroup as parameter and return a new MooseGroup with my result."
-
-	^ aMooseGroup select: [ :entity | 
-		  entity allTagAssociations anySatisfy: [ :tass | 
-			  tass tag name = tagName ] ]
+	^ aMooseGroup select: [ :entity | entity allTagAssociations anySatisfy: [ :tass | tass tag name = tagName ] ]
 ]
 
 { #category : #printing }

--- a/src/Famix-Queries/FQTypeQuery.class.st
+++ b/src/Famix-Queries/FQTypeQuery.class.st
@@ -138,19 +138,18 @@ FQTypeQuery >> isValid [
 		  types allSatisfy: [ :type | self typeIsValid: type ] ]
 ]
 
+{ #category : #running }
+FQTypeQuery >> rawRunOn: aMooseGroup [
+
+	^ self types asSet flatCollect: [ :type | aMooseGroup allMatching: type ]
+]
+
 { #category : #'adding - removing' }
 FQTypeQuery >> removeType: aType [
 
 	self types remove: aType.
 	self resetResult.
 	self flag: #FQTest , 'test reset'
-]
-
-{ #category : #running }
-FQTypeQuery >> runOn: aMooseGroup [
-	"I should run myself on the MooseGroup as parameter and return a new MooseGroup with my result."
-
-	^ (self types asSet flatCollect: [ :type | aMooseGroup allMatching: type ]) asMooseGroup
 ]
 
 { #category : #printing }

--- a/src/Famix-Queries/FQUnionQuery.class.st
+++ b/src/Famix-Queries/FQUnionQuery.class.st
@@ -31,7 +31,7 @@ FQUnionQuery >> operator [
 ]
 
 { #category : #running }
-FQUnionQuery >> runOn: mooseGroups [
+FQUnionQuery >> rawRunOn: mooseGroups [
 
 	^ mooseGroups fold: [ :a :b | a union: b ]
 ]


### PR DESCRIPTION
#runOn: is returning a MooseGroup because this is how the query model is working but sometime we want to execute some queries and we do not care that this is a moose group. And it can be pretty long to create a MooseGroup. 

I'm introducing #rawRunOn: tu return a raw collection. This will help to speedup some visualization for example by dropping multiple cast of collections.