### PR TITLE
Add rawRunOnEntity:

### DIFF
--- a/src/Famix-Queries/FQAbstractQuery.class.st
+++ b/src/Famix-Queries/FQAbstractQuery.class.st
@@ -210,6 +210,13 @@ FQAbstractQuery >> rawRunOn: aMooseGroup [
 	^ self subclassResponsibility
 ]
 
+{ #category : #running }
+FQAbstractQuery >> rawRunOnEntity: anEntity [
+	"I am a hook to allow to run a query on only one entity. I'll by default cast it as a MooseGroup but some subclasses can override me in order to speed things up."
+
+	^ self rawRunOn: anEntity asMooseGroup
+]
+
 { #category : #removing }
 FQAbstractQuery >> removeChild: aQuery [
 	children remove: aQuery

--- a/src/Famix-Queries/FQCollectScriptQuery.class.st
+++ b/src/Famix-Queries/FQCollectScriptQuery.class.st
@@ -8,6 +8,17 @@ Class {
 	#category : #'Famix-Queries-Queries-Unary'
 }
 
+{ #category : #running }
+FQCollectScriptQuery >> addResultsFor: entity in: res [
+
+	| collected |
+	collected := script value: entity.
+	collected isCollection
+		ifTrue: [ res addAll: collected ]
+		ifFalse: [ res add: collected ].
+	^ res
+]
+
 { #category : #default }
 FQCollectScriptQuery >> beDefaultForParent [
 	script := [ :each | false ]
@@ -24,11 +35,13 @@ FQCollectScriptQuery >> defaultName [
 { #category : #running }
 FQCollectScriptQuery >> rawRunOn: aMooseGroup [
 
-	^ (aMooseGroup rawAllUsing: TEntityMetaLevelDependency) inject: Set new into: [ :res :entity |
-		  | collected |
-		  collected := script value: entity.
-		  collected isCollection
-			  ifTrue: [ res addAll: collected ]
-			  ifFalse: [ res add: collected ].
-		  res ]
+	^ (aMooseGroup rawAllUsing: TEntityMetaLevelDependency) inject: Set new into: [ :res :entity | self addResultsFor: entity in: res ]
+]
+
+{ #category : #running }
+FQCollectScriptQuery >> rawRunOnEntity: anEntity [
+
+	^ anEntity isQueryable
+		  ifTrue: [ self addResultsFor: anEntity in: Set new ]
+		  ifFalse: [ #(  ) ]
 ]


### PR DESCRIPTION
This method run a query on only one entity and allows to implement faster version (This can help to speedup by 40% the speed of the architectural map)