### PR TITLE
Execute an entire sequence

### DIFF
--- a/src/Famix-Queries-Tests/FQComplementQueryTest.class.st
+++ b/src/Famix-Queries-Tests/FQComplementQueryTest.class.st
@@ -33,7 +33,7 @@ FQComplementQueryTest >> newQuery [
 { #category : #tests }
 FQComplementQueryTest >> newQueryToNegate [
 
-	^ FQRootQuery new result: helper classes
+	^ FQRootQuery new input: helper classes
 ]
 
 { #category : #tests }

--- a/src/Famix-Queries-Tests/FQNAryQueryTest.class.st
+++ b/src/Famix-Queries-Tests/FQNAryQueryTest.class.st
@@ -109,9 +109,9 @@ FQNAryQueryTest >> testParents [
 
 { #category : #tests }
 FQNAryQueryTest >> testResult [
-	query subqueries
-		do:
-			[ :parent | parent parent: (FQRootQuery new result: helper classesAndMethods) ].
+
+	query subqueries do: [ :parent |
+		parent parent: (FQRootQuery new input: helper classesAndMethods) ].
 	self
 		assertCollection: query result
 		hasSameElements: (query runOn: self parentQueriesResult)

--- a/src/Famix-Queries-Tests/FQNavigationQueryTest.class.st
+++ b/src/Famix-Queries-Tests/FQNavigationQueryTest.class.st
@@ -88,10 +88,11 @@ FQNavigationQueryTest >> incomingAccessesForClassExample [
 
 { #category : #'running - queries' }
 FQNavigationQueryTest >> incomingAllAssociationsQuery [
+
 	^ self actualClass new
-		directionStrategy: FQIncomingNavigation;
-		associationStrategy: FQAllNavigationAssociations new;
-		beChildOf: (FQRootQuery new result: helper classesAndMethods)
+		  directionStrategy: FQIncomingNavigation;
+		  associationStrategy: FQAllNavigationAssociations new;
+		  beChildOf: (FQRootQuery new input: helper classesAndMethods)
 ]
 
 { #category : #'class example' }
@@ -151,10 +152,11 @@ FQNavigationQueryTest >> incomingTest [
 
 { #category : #'running - queries' }
 FQNavigationQueryTest >> localIncomingAllAssociationsQuery [
+
 	^ self actualClass new
-		directionStrategy: FQLocalIncomingNavigation;
-		associationStrategy: FQAllNavigationAssociations new;
-		beChildOf: (FQRootQuery new result: helper classesAndMethods)
+		  directionStrategy: FQLocalIncomingNavigation;
+		  associationStrategy: FQAllNavigationAssociations new;
+		  beChildOf: (FQRootQuery new input: helper classesAndMethods)
 ]
 
 { #category : #'class example' }
@@ -172,10 +174,11 @@ FQNavigationQueryTest >> localIncomingReferencesForClassExample [
 
 { #category : #'running - queries' }
 FQNavigationQueryTest >> localOutgoingAllAssociationsQuery [
+
 	^ self actualClass new
-		directionStrategy: FQLocalOutgoingNavigation;
-		associationStrategy: FQAllNavigationAssociations new;
-		beChildOf: (FQRootQuery new result: helper classesAndMethods)
+		  directionStrategy: FQLocalOutgoingNavigation;
+		  associationStrategy: FQAllNavigationAssociations new;
+		  beChildOf: (FQRootQuery new input: helper classesAndMethods)
 ]
 
 { #category : #'class example' }
@@ -243,10 +246,11 @@ FQNavigationQueryTest >> outgoingAccessesForClassExample [
 
 { #category : #'running - queries' }
 FQNavigationQueryTest >> outgoingAllAssociationsQuery [
+
 	^ self actualClass new
-		directionStrategy: FQOutgoingNavigation;
-		associationStrategy: FQAllNavigationAssociations new;
-		beChildOf: (FQRootQuery new result: helper classesAndMethods)
+		  directionStrategy: FQOutgoingNavigation;
+		  associationStrategy: FQAllNavigationAssociations new;
+		  beChildOf: (FQRootQuery new input: helper classesAndMethods)
 ]
 
 { #category : #'class example' }
@@ -299,12 +303,13 @@ FQNavigationQueryTest >> outgoingTest [
 
 { #category : #'tests - adding - removing' }
 FQNavigationQueryTest >> testAddAllAssociations [
+
 	query associationStrategy: FQNavigationAssociations new.
-	query parent: (FQRootQuery new result: helper classesAndMethods).
-	
-	query availableAssociations
-		do: [ :assoc | query addAssociation: assoc ].
-	
+	query parent: (FQRootQuery new input: helper classesAndMethods).
+
+	query availableAssociations do: [ :assoc |
+		query addAssociation: assoc ].
+
 	self
 		assert: query associationStrategy class
 		identicalTo: FQAllNavigationAssociations
@@ -384,7 +389,7 @@ FQNavigationQueryTest >> testName [
 { #category : #'tests - adding - removing' }
 FQNavigationQueryTest >> testRemoveAssociation [
 
-	query parent: (FQRootQuery new result: helper classesAndMethods).
+	query parent: (FQRootQuery new input: helper classesAndMethods).
 	query removeAssociation: FamixStAccess.
 	self deny: (query associations includes: FamixStAccess).
 	self

--- a/src/Famix-Queries-Tests/FQRootQueryTest.class.st
+++ b/src/Famix-Queries-Tests/FQRootQueryTest.class.st
@@ -35,8 +35,9 @@ FQRootQueryTest >> testDisplayOn [
 
 { #category : #tests }
 FQRootQueryTest >> testIsValid [
+
 	self assert: query isValid.
-	query result: nil.
+	query input: nil.
 	self deny: query isValid
 ]
 

--- a/src/Famix-Queries-Tests/FQSequenceQueryTest.class.st
+++ b/src/Famix-Queries-Tests/FQSequenceQueryTest.class.st
@@ -1,0 +1,93 @@
+Class {
+	#name : #FQSequenceQueryTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'helper',
+		'querySequence',
+		'nAryQuerySequence',
+		'complementQuerySequence'
+	],
+	#category : #'Famix-Queries-Tests-Core'
+}
+
+{ #category : #'as yet unclassified' }
+FQSequenceQueryTest >> initializeComplementQuerySequence [
+
+	complementQuerySequence := FQComplementQuery queryToNegate:
+		                           (FQTypeQuery types: { FamixStClass })
+]
+
+{ #category : #'as yet unclassified' }
+FQSequenceQueryTest >> initializeNAryQuerySequence [
+
+	nAryQuerySequence := (FQTypeQuery types: { FamixStClass })
+	                     | (FQStringQuery
+			                      property: #name
+			                      comparator: #beginsWith:
+			                      valueToCompare: 'i')
+]
+
+{ #category : #'as yet unclassified' }
+FQSequenceQueryTest >> initializeQuerySequence [
+
+	querySequence := (FQTypeQuery types: { FamixStClass })
+	                 --> (FQScopeQuery downTo: FamixStMethod)
+	                 --> (FQStringQuery
+			                  property: #name
+			                  comparator: #beginsWith:
+			                  valueToCompare: 'i')
+]
+
+{ #category : #'as yet unclassified' }
+FQSequenceQueryTest >> querySequence [
+
+	^ querySequence
+]
+
+{ #category : #running }
+FQSequenceQueryTest >> setUp [
+
+	super setUp.
+	helper := FQTestsHelper new.
+	self initializeQuerySequence.
+	self initializeNAryQuerySequence.
+	self initializeComplementQuerySequence
+]
+
+{ #category : #tests }
+FQSequenceQueryTest >> testExecuteOn [
+
+	self
+		assertCollection:
+		(self querySequence executeOn: helper modelExample)
+		hasSameElements: (querySequence runOn: (querySequence parent runOn:
+					  (querySequence parent parent runOn: helper modelExample)))
+]
+
+{ #category : #tests }
+FQSequenceQueryTest >> testExecuteOnWithComplementQuery [
+
+	self
+		denyCollection: (OrderedCollection withAll:
+				 (complementQuerySequence executeOn: helper modelExample))
+		includesAny:
+		(complementQuerySequence queryToNegate executeOn:
+			 helper modelExample)
+]
+
+{ #category : #tests }
+FQSequenceQueryTest >> testExecuteOnWithNAryQuery [
+
+	self
+		assertCollection: (nAryQuerySequence executeOn: helper modelExample)
+		hasSameElements:
+			(nAryQuerySequence subqueries first executeOn: helper modelExample)
+			|
+			(nAryQuerySequence subqueries second executeOn: helper modelExample)
+]
+
+{ #category : #tests }
+FQSequenceQueryTest >> testHasParent [
+
+	self assert: querySequence parent isNotNil
+]

--- a/src/Famix-Queries-Tests/FQUnaryQueryTest.class.st
+++ b/src/Famix-Queries-Tests/FQUnaryQueryTest.class.st
@@ -12,7 +12,7 @@ FQUnaryQueryTest class >> isAbstract [
 { #category : #'instance creation' }
 FQUnaryQueryTest >> newParentQuery [
 
-	^ FQRootQuery new result: helper classes
+	^ FQRootQuery new input: helper classes
 ]
 
 { #category : #tests }

--- a/src/Famix-Queries/FQAbstractQuery.class.st
+++ b/src/Famix-Queries/FQAbstractQuery.class.st
@@ -114,6 +114,16 @@ FQAbstractQuery >> displayOn: aStream [
 	^ self subclassResponsibility
 ]
 
+{ #category : #execution }
+FQAbstractQuery >> executeOn: aMooseGroup [
+
+	| root |
+
+	root := FQRootQuery new input: aMooseGroup.
+	self rootQuery: root.
+	^ self result
+]
+
 { #category : #accessing }
 FQAbstractQuery >> hasSameParametersAs: arg1 [ 
 	^ self subclassResponsibility
@@ -233,6 +243,12 @@ FQAbstractQuery >> result [
 
 	result ifNil: [ result := self computeResult ].
 	^ result
+]
+
+{ #category : #execution }
+FQAbstractQuery >> rootQuery: aFQRootQuery [
+
+	self subclassResponsibility
 ]
 
 { #category : #running }

--- a/src/Famix-Queries/FQComplementQuery.class.st
+++ b/src/Famix-Queries/FQComplementQuery.class.st
@@ -108,6 +108,12 @@ FQComplementQuery >> rawRunOn: allEntitiesMooseGroup [
 	^ newItems
 ]
 
+{ #category : #execution }
+FQComplementQuery >> rootQuery: aFQRootQuery [
+
+	queryToNegate rootQuery: aFQRootQuery
+]
+
 { #category : #printing }
 FQComplementQuery >> storeOn: aStream [
 

--- a/src/Famix-Queries/FQNAryQuery.class.st
+++ b/src/Famix-Queries/FQNAryQuery.class.st
@@ -115,6 +115,12 @@ FQNAryQuery >> prepareRemoval [
 	subqueries := nil
 ]
 
+{ #category : #execution }
+FQNAryQuery >> rootQuery: aFQRootQuery [
+
+	self subqueries do: [ :subquery | subquery rootQuery: aFQRootQuery ]
+]
+
 { #category : #printing }
 FQNAryQuery >> storeOn: aStream [
 

--- a/src/Famix-Queries/FQRootQuery.class.st
+++ b/src/Famix-Queries/FQRootQuery.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : #FQRootQuery,
 	#superclass : #FQUnaryQuery,
+	#instVars : [
+		'input'
+	],
 	#category : #'Famix-Queries-Queries-Unary'
 }
 
@@ -45,8 +48,15 @@ FQRootQuery >> hasSameParametersAs: aQuery [
 
 { #category : #initialization }
 FQRootQuery >> initialize [
+
 	super initialize.
-	result := MooseGroup new
+	input := MooseGroup new
+]
+
+{ #category : #accessing }
+FQRootQuery >> input: aMooseGroup [
+
+	input := aMooseGroup
 ]
 
 { #category : #testing }
@@ -56,7 +66,8 @@ FQRootQuery >> isRootQuery [
 
 { #category : #testing }
 FQRootQuery >> isValid [
-	^ result isKindOf: MooseGroup
+
+	^ input isKindOf: MooseGroup
 ]
 
 { #category : #running }
@@ -64,9 +75,20 @@ FQRootQuery >> rawRunOn: aMooseGroup [
 	^ aMooseGroup
 ]
 
+{ #category : #running }
+FQRootQuery >> result [
+
+	^ input
+]
+
 { #category : #accessing }
 FQRootQuery >> result: aMooseGroup [
-	result := aMooseGroup
+
+	self
+		deprecated: 'Unclear method name'
+		transformWith:
+		'`@receiver result: `@arg' -> '`@receiver input: `@arg'.
+	self input: aMooseGroup
 ]
 
 { #category : #printing }

--- a/src/Famix-Queries/FQUnaryQuery.class.st
+++ b/src/Famix-Queries/FQUnaryQuery.class.st
@@ -169,6 +169,14 @@ FQUnaryQuery >> resetParent [
 	parent := nil
 ]
 
+{ #category : #execution }
+FQUnaryQuery >> rootQuery: aFQRootQuery [
+
+	self parent
+		ifNil: [ self parent: aFQRootQuery ]
+		ifNotNil: [ self parent rootQuery: aFQRootQuery ]
+]
+
 { #category : #printing }
 FQUnaryQuery >> storeWithParentsOn: aStream [
 


### PR DESCRIPTION
Add #rootQuery: to set a root query as parent of the last query in a parent sequence.

Add #executeOn: to execute the full parent sequence of any query.
+ adding tests
+ renaming RootQuery result to #input