### PR TITLE
Implement query hash and equality

### DIFF
--- a/src/Famix-Queries-Tests/FQAbstractQueryTest.class.st
+++ b/src/Famix-Queries-Tests/FQAbstractQueryTest.class.st
@@ -70,6 +70,20 @@ FQAbstractQueryTest >> testDisplayOn [
 ]
 
 { #category : #tests }
+FQAbstractQueryTest >> testEqual [
+
+	self assert: query equals: query copy.
+	self deny: query equals: FQNullQuery new
+]
+
+{ #category : #tests }
+FQAbstractQueryTest >> testHash [
+
+	self assert: query hash equals: query copy hash.
+	self deny: query hash equals: FQNullQuery new hash
+]
+
+{ #category : #tests }
 FQAbstractQueryTest >> testIsValid [
 	self assert: query isValid.
 	self deny: self unConfiguredQuery isValid

--- a/src/Famix-Queries/FQAbstractQuery.class.st
+++ b/src/Famix-Queries/FQAbstractQuery.class.st
@@ -63,6 +63,13 @@ FQAbstractQuery >> & anotherQuery [
 	^ self intersection: anotherQuery
 ]
 
+{ #category : #comparing }
+FQAbstractQuery >> = anObject [
+
+	^ self class == anObject class and: [
+		  self hasSameParametersAs: anObject ]
+]
+
 { #category : #composition }
 FQAbstractQuery >> \ anotherQuery [
 
@@ -125,8 +132,14 @@ FQAbstractQuery >> executeOn: aMooseGroup [
 ]
 
 { #category : #accessing }
-FQAbstractQuery >> hasSameParametersAs: arg1 [ 
+FQAbstractQuery >> hasSameParametersAs: aQuery [ 
 	^ self subclassResponsibility
+]
+
+{ #category : #comparing }
+FQAbstractQuery >> hash [
+
+	^ (name hash bitXor: result hash) bitXor: children hash
 ]
 
 { #category : #initialization }

--- a/src/Famix-Queries/FQComplementQuery.class.st
+++ b/src/Famix-Queries/FQComplementQuery.class.st
@@ -67,6 +67,12 @@ FQComplementQuery >> hasSameParametersAs: aQuery [
 	^ aQuery queryToNegate hasSameParametersAs: queryToNegate
 ]
 
+{ #category : #comparing }
+FQComplementQuery >> hash [
+
+	^ super hash bitXor: queryToNegate hash
+]
+
 { #category : #testing }
 FQComplementQuery >> isValid [
 

--- a/src/Famix-Queries/FQNAryQuery.class.st
+++ b/src/Famix-Queries/FQNAryQuery.class.st
@@ -81,6 +81,12 @@ FQNAryQuery >> hasSameSubqueriesAs: aQuery [
 	^ self subqueries = aQuery subqueries
 ]
 
+{ #category : #comparing }
+FQNAryQuery >> hash [
+
+	^ super hash bitXor: subqueries hash
+]
+
 { #category : #initialization }
 FQNAryQuery >> initialize [
 	super initialize.

--- a/src/Famix-Queries/FQNavigationQuery.class.st
+++ b/src/Famix-Queries/FQNavigationQuery.class.st
@@ -218,6 +218,13 @@ FQNavigationQuery >> hasSameParametersAs: aQuery [
 		and: [ associationStrategy = aQuery associationStrategy ]
 ]
 
+{ #category : #comparing }
+FQNavigationQuery >> hash [
+
+	^ (super hash bitXor: directionStrategy hash) bitXor:
+		  associationStrategy hash
+]
+
 { #category : #initialization }
 FQNavigationQuery >> initialize [
 	super initialize.

--- a/src/Famix-Queries/FQNullQuery.class.st
+++ b/src/Famix-Queries/FQNullQuery.class.st
@@ -26,9 +26,9 @@ FQNullQuery >> displayOn: aStream [
 ]
 
 { #category : #accessing }
-FQNullQuery >> hasSameParametersAs: arg1 [
+FQNullQuery >> hasSameParametersAs: aQuery [
 
-	^ false
+	^ self class == aQuery class
 ]
 
 { #category : #testing }

--- a/src/Famix-Queries/FQNumericQuery.class.st
+++ b/src/Famix-Queries/FQNumericQuery.class.st
@@ -81,6 +81,12 @@ FQNumericQuery >> hasSameParametersAs: aQuery [
 				and: [ valueToCompare = aQuery valueToCompare ] ]
 ]
 
+{ #category : #comparing }
+FQNumericQuery >> hash [
+
+	^ (super hash bitXor: valueToCompare hash) bitXor: comparator hash
+]
+
 { #category : #testing }
 FQNumericQuery >> isValid [
 

--- a/src/Famix-Queries/FQPropertyQuery.class.st
+++ b/src/Famix-Queries/FQPropertyQuery.class.st
@@ -154,6 +154,12 @@ FQPropertyQuery >> hasSameParametersAs: aQuery [
 	^ property == aQuery property
 ]
 
+{ #category : #comparing }
+FQPropertyQuery >> hash [
+
+	^ super hash bitXor: property hash
+]
+
 { #category : #testing }
 FQPropertyQuery >> isValid [
 	^ self property isSymbol

--- a/src/Famix-Queries/FQRelationQuery.class.st
+++ b/src/Famix-Queries/FQRelationQuery.class.st
@@ -94,6 +94,12 @@ FQRelationQuery >> hasSameParametersAs: aQuery [
 	^ aQuery relationName = self relationName
 ]
 
+{ #category : #comparing }
+FQRelationQuery >> hash [
+
+	^ super hash bitXor: relationName hash
+]
+
 { #category : #testing }
 FQRelationQuery >> isValid [
 

--- a/src/Famix-Queries/FQResultSizeQuery.class.st
+++ b/src/Famix-Queries/FQResultSizeQuery.class.st
@@ -82,6 +82,13 @@ FQResultSizeQuery >> hasSameParametersAs: aQuery [
 			  valueToCompare = aQuery valueToCompare ]
 ]
 
+{ #category : #comparing }
+FQResultSizeQuery >> hash [
+
+	^ ((super hash bitXor: innerQuery hash) bitXor: comparator hash)
+		  bitXor: valueToCompare hash
+]
+
 { #category : #accessing }
 FQResultSizeQuery >> innerQuery [
 

--- a/src/Famix-Queries/FQRootQuery.class.st
+++ b/src/Famix-Queries/FQRootQuery.class.st
@@ -46,6 +46,12 @@ FQRootQuery >> hasSameParametersAs: aQuery [
 	^ true
 ]
 
+{ #category : #comparing }
+FQRootQuery >> hash [
+
+	^ super hash bitXor: input hash
+]
+
 { #category : #initialization }
 FQRootQuery >> initialize [
 

--- a/src/Famix-Queries/FQScopeQuery.class.st
+++ b/src/Famix-Queries/FQScopeQuery.class.st
@@ -164,8 +164,16 @@ FQScopeQuery >> displayOn: aStream with: aString [
 
 { #category : #comparing }
 FQScopeQuery >> hasSameParametersAs: aQuery [
-	^ direction == aQuery directionStrategy
-		and: [ scope == aQuery scope ]
+
+	^ direction == aQuery directionStrategy and: [
+		  scope == aQuery scope and: [ recursive == aQuery recursive ] ]
+]
+
+{ #category : #comparing }
+FQScopeQuery >> hash [
+
+	^ ((super hash bitXor: scope hash) bitXor: direction hash) bitXor:
+		  recursive hash
 ]
 
 { #category : #initialization }

--- a/src/Famix-Queries/FQScriptQuery.class.st
+++ b/src/Famix-Queries/FQScriptQuery.class.st
@@ -29,6 +29,12 @@ FQScriptQuery >> hasSameParametersAs: aQuery [
 	^ script asString = aQuery script asString
 ]
 
+{ #category : #comparing }
+FQScriptQuery >> hash [
+
+	^ super hash bitXor: script hash
+]
+
 { #category : #testing }
 FQScriptQuery >> isScriptQuery [
 

--- a/src/Famix-Queries/FQStringQuery.class.st
+++ b/src/Famix-Queries/FQStringQuery.class.st
@@ -82,6 +82,12 @@ FQStringQuery >> hasSameParametersAs: aQuery [
 				and: [ valueToCompare = aQuery valueToCompare ] ]
 ]
 
+{ #category : #comparing }
+FQStringQuery >> hash [
+
+	^ (super hash bitXor: valueToCompare hash) bitXor: comparator hash
+]
+
 { #category : #testing }
 FQStringQuery >> isValid [
 	super isValid ifFalse: [ ^ false ].

--- a/src/Famix-Queries/FQTaggedEntityQuery.class.st
+++ b/src/Famix-Queries/FQTaggedEntityQuery.class.st
@@ -102,6 +102,12 @@ FQTaggedEntityQuery >> hasSameParametersAs: aQuery [
 	^ aQuery tagName = self tagName
 ]
 
+{ #category : #comparing }
+FQTaggedEntityQuery >> hash [
+
+	^ super hash bitXor: tagName hash
+]
+
 { #category : #testing }
 FQTaggedEntityQuery >> isValid [
 	^ tagName isNotNil

--- a/src/Famix-Queries/FQTypeQuery.class.st
+++ b/src/Famix-Queries/FQTypeQuery.class.st
@@ -125,6 +125,12 @@ FQTypeQuery >> hasSameParametersAs: aQuery [
 	^ types = aQuery types
 ]
 
+{ #category : #comparing }
+FQTypeQuery >> hash [
+
+	^ super hash bitXor: types hash
+]
+
 { #category : #initialization }
 FQTypeQuery >> initialize [
 	super initialize.


### PR DESCRIPTION
Since queries were being copied since last month's sprint, this led to some issues when tag browser and others rely on equality, resulting in duplicate queries in lists or error detecting it.