### PR TITLE
Update properties queries to take the unions of possible properties

### DIFF
--- a/src/Famix-Queries-Tests/FQPropertyQueryTest.class.st
+++ b/src/Famix-Queries-Tests/FQPropertyQueryTest.class.st
@@ -23,14 +23,11 @@ FQPropertyQueryTest >> propertyType [
 
 { #category : 'tests - available parameters' }
 FQPropertyQueryTest >> testAvailablePropertiesFor [
-	(self unConfiguredQuery
-		availablePropertiesFor: helper classesAndMethods)
-		do: [ :propertySelector | 
+
+	(self unConfiguredQuery availablePropertiesFor: helper classesAndMethods) do: [ :propertySelector |
 			self assert: propertySelector isSymbol.
-			helper classesAndMethods
-				do: [ :entity | 
-					self
-						assert: ((entity perform: propertySelector) isKindOf: self propertyType) ] ]
+			helper classesAndMethods do: [ :entity | "Not all entities can answer to everything and sometimes the properties are nil."
+				(entity respondsTo: propertySelector) ifTrue: [ (entity perform: propertySelector) ifNotNil: [ :value | self assert: (value isKindOf: self propertyType) ] ] ] ]
 ]
 
 { #category : 'tests' }

--- a/src/Famix-Queries/FQPropertyQuery.class.st
+++ b/src/Famix-Queries/FQPropertyQuery.class.st
@@ -49,11 +49,7 @@ Class {
 { #category : 'accessing' }
 FQPropertyQuery class >> availablePropertiesFor: aMooseGroup [
 
-	^ ((aMooseGroup allEntityTypes collect: [ :entity | 
-		    entity famePropertiesOfType: self type ]) fold: [ 
-		   :availableProperties 
-		   :entityProperties | availableProperties & entityProperties ]) 
-		  collect: #implementingSelector
+	^ (aMooseGroup allEntityTypes collect: [ :entity | entity famePropertiesOfType: self type ]) flatten collect: #implementingSelector
 ]
 
 { #category : 'available parameters' }


### PR DESCRIPTION
In property queries, we were using intersection of all properties of entities. Now I'm reverting that to the old implementation of taking the union. Fixes https://github.com/moosetechnology/MooseIDE/issues/1375