### PR TITLE
Speed up multiple queries

### DIFF
--- a/src/Famix-Queries-Tests/FQTypeQueryTest.class.st
+++ b/src/Famix-Queries-Tests/FQTypeQueryTest.class.st
@@ -14,7 +14,7 @@ FQTypeQueryTest >> actualClass [
 { #category : 'tests - available parameters' }
 FQTypeQueryTest >> allNamedEntitiesTypes [
 
-	^ (helper modelExample rawAllUsing: FamixTNamedEntity) collect: #class
+	^ (helper modelExample rawAllUsing: TEntityMetaLevelDependency) collectAsSet: #class
 ]
 
 { #category : 'tests - running' }

--- a/src/Famix-Queries/FQAbstractNavigationDirection.class.st
+++ b/src/Famix-Queries/FQAbstractNavigationDirection.class.st
@@ -30,22 +30,15 @@ FQAbstractNavigationDirection class >> associationsFor: aMooseGroup [
 
 { #category : 'accessing' }
 FQAbstractNavigationDirection class >> availableAssociationsFor: aMooseGroup [
+
 	| associations model |
-	aMooseGroup ifEmpty: [ ^ #() ].
+	aMooseGroup ifEmpty: [ ^ #(  ) ].
 	associations := self associationsFor: aMooseGroup.
 	model := aMooseGroup isMooseModel
-		ifTrue: [ aMooseGroup ]
-		ifFalse: [ aMooseGroup mooseModel ].
-	
-	^ ((model allEntityTypes
-		select: [ :class | 
-			associations
-				anySatisfy: [ :type | class = type or: [ class allTraits includes: type ] ] ])
-		flatCollect: #withAllSubclasses)
-	
-	"This is for compatibilty MM"
-		select:
-			[ :class | (model metamodel classes collect: #implementingClass) includes: class ]
+		         ifTrue: [ aMooseGroup ]
+		         ifFalse: [ aMooseGroup mooseModel ].
+
+	^ (model allAssociationTypes select: [ :class | associations anySatisfy: [ :type | class isOfType: type ] ]) flatCollect: #withAllSubclasses
 ]
 
 { #category : 'printing' }

--- a/src/Famix-Queries/MooseAbstractGroup.extension.st
+++ b/src/Famix-Queries/MooseAbstractGroup.extension.st
@@ -1,6 +1,17 @@
 Extension { #name : 'MooseAbstractGroup' }
 
 { #category : '*Famix-Queries' }
+MooseAbstractGroup >> allAssociationTypes [
+
+	^ self
+		  cacheAt: #allAssociationTypes
+		  ifAbsentPut: [  (self collectAsSet: #class) select: [ :each | each withAllSuperclasses anySatisfy: [ :e | e isComposedBy: TAssociationMetaLevelDependency ] ] ]
+]
+
+{ #category : '*Famix-Queries' }
 MooseAbstractGroup >> allEntityTypes [
-	^ self collectAsSet: #class
+
+	^ self
+		  cacheAt: #allEntityTypes
+		  ifAbsentPut: [ (self collectAsSet: #class) select: [ :class | class withAllSuperclasses anySatisfy: [ :each | each isComposedBy: TEntityMetaLevelDependency ] ] ]
 ]


### PR DESCRIPTION
- Some by selecting only associations and not other entities
- Some by selecting only "domain" objects and not associations
- Somme by adding caches on Moose groups